### PR TITLE
Fix failures and make it fail if there are failures.

### DIFF
--- a/.github/workflows/validate-templates.yaml
+++ b/.github/workflows/validate-templates.yaml
@@ -36,3 +36,9 @@ jobs:
         run: |
           cd rhel-jboss-templates
           ./validateOffers.sh
+          if [ $? -eq 0 ]; then
+              echo "ARM TTK succeeded."
+          else
+              echo "ARM TTK failed."
+              exit 1
+          fi

--- a/eap73-rhel8-byos-multivm/src/main/arm/mainTemplate.json
+++ b/eap73-rhel8-byos-multivm/src/main/arm/mainTemplate.json
@@ -543,7 +543,7 @@
   "outputs": {
     "appURL": {
       "type": "string",
-      "value": "[concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress, '/eap-session-replication/')]"
+      "value": "[uri(concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress), 'eap-session-replication/')]"
     }
   }
 }

--- a/eap73-rhel8-byos-vmss/src/main/arm/mainTemplate.json
+++ b/eap73-rhel8-byos-vmss/src/main/arm/mainTemplate.json
@@ -494,7 +494,7 @@
   "outputs": {
     "appURL": {
       "type": "string",
-      "value": "[concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress, '/eap-session-replication/')]"
+      "value": "[uri(concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress), 'eap-session-replication/')]"
     }
   }
 }

--- a/eap73-rhel8-payg-multivm/src/main/arm/mainTemplate.json
+++ b/eap73-rhel8-payg-multivm/src/main/arm/mainTemplate.json
@@ -530,7 +530,7 @@
   "outputs": {
     "appURL": {
       "type": "string",
-      "value": "[concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress, '/eap-session-replication/')]"
+      "value": "[uri(concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress), 'eap-session-replication/')]"
     }
   }
 }

--- a/eap73-rhel8-payg-vmss/src/main/arm/mainTemplate.json
+++ b/eap73-rhel8-payg-vmss/src/main/arm/mainTemplate.json
@@ -480,7 +480,7 @@
   "outputs": {
     "appURL": {
       "type": "string",
-      "value": "[concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress, '/eap-session-replication/')]"
+      "value": "[uri(concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress), 'eap-session-replication/')]"
     }
   }
 }

--- a/eap74-rhel8-byos-multivm/src/main/arm/mainTemplate.json
+++ b/eap74-rhel8-byos-multivm/src/main/arm/mainTemplate.json
@@ -543,7 +543,7 @@
   "outputs": {
     "appURL": {
       "type": "string",
-      "value": "[concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress, '/eap-session-replication/')]"
+      "value": "[uri(concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress), 'eap-session-replication/')]"
     }
   }
 }

--- a/eap74-rhel8-byos-vmss/src/main/arm/mainTemplate.json
+++ b/eap74-rhel8-byos-vmss/src/main/arm/mainTemplate.json
@@ -494,7 +494,7 @@
   "outputs": {
     "appURL": {
       "type": "string",
-      "value": "[concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress, '/eap-session-replication/')]"
+      "value": "[uri(concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress), 'eap-session-replication/')]"
     }
   }
 }

--- a/eap74-rhel8-payg-multivm/src/main/arm/mainTemplate.json
+++ b/eap74-rhel8-payg-multivm/src/main/arm/mainTemplate.json
@@ -530,7 +530,7 @@
   "outputs": {
     "appURL": {
       "type": "string",
-      "value": "[concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress, '/eap-session-replication/')]"
+      "value": "[uri(concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress), 'eap-session-replication/')]"
     }
   }
 }

--- a/eap74-rhel8-payg-vmss/src/main/arm/mainTemplate.json
+++ b/eap74-rhel8-payg-vmss/src/main/arm/mainTemplate.json
@@ -480,7 +480,7 @@
   "outputs": {
     "appURL": {
       "type": "string",
-      "value": "[concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress, '/eap-session-replication/')]"
+      "value": "[uri(concat('http://', reference(variables('loadBalancersName')).frontendIPConfigurations[0].properties.privateIPAddress) 'eap-session-replication/')]"
     }
   }
 }

--- a/validateOffers.sh
+++ b/validateOffers.sh
@@ -16,10 +16,22 @@ msg() {
 
 setup_colors
 
+success=0
+failureIndicator='[-]'
 for d in */ ; do
     folderName=$(basename $d)
     if [[ $folderName == $OFFER_PATH_PATTERN ]]; then
         msg "${YELLOW}matched folder name: $folderName. Full path is: ${BASE_DIR}/${folderName}/src/main/arm ${NOFORMAT}"
-        ./../arm-ttk/arm-ttk/Test-AzTemplate.sh -TemplatePath ${BASE_DIR}/${folderName}/src/main/arm
+        ttkResult=$(./../arm-ttk/arm-ttk/Test-AzTemplate.sh -TemplatePath ${BASE_DIR}/${folderName}/src/main/arm)
+        if [[ "${ttkResult}" == *${failureIndicator}* ]]; then
+            success=1
+        fi
+        echo ${ttkResult}
     fi
 done
+
+if [ ${success} -eq 1 ]; then
+    exit 1
+else
+    exit 0
+fi

--- a/validateOffers.sh
+++ b/validateOffers.sh
@@ -16,21 +16,24 @@ msg() {
 
 setup_colors
 
-success=0
-failureIndicator='[-]'
+rc=0
+failureIndicator='\[-\]'
 for d in */ ; do
     folderName=$(basename $d)
     if [[ $folderName == $OFFER_PATH_PATTERN ]]; then
         msg "${YELLOW}matched folder name: $folderName. Full path is: ${BASE_DIR}/${folderName}/src/main/arm ${NOFORMAT}"
-        ttkResult=$(./../arm-ttk/arm-ttk/Test-AzTemplate.sh -TemplatePath ${BASE_DIR}/${folderName}/src/main/arm)
-        if [[ "${ttkResult}" == *${failureIndicator}* ]]; then
-            success=1
+        ./../arm-ttk/arm-ttk/Test-AzTemplate.sh -TemplatePath ${BASE_DIR}/${folderName}/src/main/arm | tee testOutput
+        set +e ; grep -q ${failureIndicator} testOutput;
+        if [ $? -eq 0 ]; then
+            msg "${RED}FAILURE in ${BASE_DIR}/${folderName}"
+            rc=1
         fi
-        echo ${ttkResult}
+        rm testOutput
+        set -e
     fi
 done
 
-if [ ${success} -eq 1 ]; then
+if [ ${rc} -eq 1 ]; then
     exit 1
 else
     exit 0


### PR DESCRIPTION
On branch edburns-msft-55-ttk-failures-not-heeded
modified:   eap73-rhel8-byos-multivm/src/main/arm/mainTemplate.json
modified:   eap73-rhel8-byos-vmss/src/main/arm/mainTemplate.json
modified:   eap73-rhel8-payg-multivm/src/main/arm/mainTemplate.json
modified:   eap73-rhel8-payg-vmss/src/main/arm/mainTemplate.json
modified:   eap74-rhel8-byos-multivm/src/main/arm/mainTemplate.json
modified:   eap74-rhel8-byos-vmss/src/main/arm/mainTemplate.json
modified:   eap74-rhel8-payg-multivm/src/main/arm/mainTemplate.json
modified:   eap74-rhel8-payg-vmss/src/main/arm/mainTemplate.json

- Fix TTK failure: Within `outputs` properties that end in `URI` or
  `URL`, one must not use `concat` or `format` **unless** within `uri`.

modified:   validateOffers.sh

- I observe that `Test-AzTemplate.sh` returns 0 regardless of whether
  or not there are failures in the set of tests.  Thus, to examine
  whether or not there are failures, I capture the output of
  `Test-AzTemplate.sh` to a file and grep it for a `failureIndicator`.
  However, because of `set -e`, I must temporarily disable `set -e` so
  that I can use `grep` without causing the script to exit prematurely.

