### PR TITLE
Use curl instead of wget when downloading sample app due to certificate expiration

### DIFF
--- a/eap73-rhel8-byos-multivm/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap73-rhel8-byos-multivm/src/main/scripts/jbosseap-setup-redhat.sh
@@ -108,9 +108,9 @@ fi
 
 
 ####################### Install openjdk: is it needed? it should be installed with eap7.3
-echo "Install openjdk, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
-echo "sudo yum install java-1.8.4-openjdk wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}
-sudo yum install wget unzip vim git -y | log; flag=${PIPESTATUS[0]}
+echo "Install openjdk, curl, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
+echo "sudo yum install java-1.8.4-openjdk curl wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}
+sudo yum install curl wget unzip vim git -y | log; flag=${PIPESTATUS[0]}
 ####################### 
 
 
@@ -188,8 +188,8 @@ systemctl status eap7-standalone.service        | log; flag=${PIPESTATUS[0]}
 ######################
 
 echo "Deploy an application" | log; flag=${PIPESTATUS[0]}
-echo "wget -O eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
-wget -O "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
+echo "curl -o eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
+curl -o "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
 if [ $flag != 0 ] ; then echo  "ERROR! Sample Application Download Failed" >&2 log; exit $flag; fi
 echo "cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/" | log; flag=${PIPESTATUS[0]}
 cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/ | log; flag=${PIPESTATUS[0]}

--- a/eap73-rhel8-byos-vmss/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap73-rhel8-byos-vmss/src/main/scripts/jbosseap-setup-redhat.sh
@@ -99,9 +99,9 @@ fi
 #######################
 
 ####################### Install openjdk: is it needed? it should be installed with eap7.3
-echo "Install openjdk, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
-echo "sudo yum install java-1.8.4-openjdk wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}install.log
-sudo yum install wget unzip vim git -y | log; flag=${PIPESTATUS[0]} #java-1.8.4-openjdk
+echo "Install openjdk, curl, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
+echo "sudo yum install java-1.8.4-openjdk curl wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}install.log
+sudo yum install curl wget unzip vim git -y | log; flag=${PIPESTATUS[0]} #java-1.8.4-openjdk
 ####################### 
 
 
@@ -178,8 +178,8 @@ systemctl status eap7-standalone.service        | log; flag=${PIPESTATUS[0]}
 ######################
 
 echo "Deploy an application" | log; flag=${PIPESTATUS[0]}
-echo "wget -O eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
-wget -O "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
+echo "curl -o eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
+curl -o "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
 if [ $flag != 0 ] ; then echo  "ERROR! Sample Application Download Failed" >&2 log; exit $flag; fi
 echo "cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/" | log; flag=${PIPESTATUS[0]}
 cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/ | log; flag=${PIPESTATUS[0]} 

--- a/eap73-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap73-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
@@ -95,9 +95,9 @@ if [ $flag != 0 ] ; then echo  "ERROR! Pool Attach for JBoss EAP Failed" >&2 log
 #######################
 
 ####################### Install openjdk: is it needed? it should be installed with eap7.3
-echo "Install openjdk, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
-echo "sudo yum install java-1.8.4-openjdk wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}
-sudo yum install wget unzip vim git -y | log; flag=${PIPESTATUS[0]}#java-1.8.4-openjdk
+echo "Install openjdk, curl, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
+echo "sudo yum install java-1.8.4-openjdk curl wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}
+sudo yum install curl wget unzip vim git -y | log; flag=${PIPESTATUS[0]}#java-1.8.4-openjdk
 ####################### 
 
 ####################### Install JBoss EAP 7.3
@@ -171,8 +171,8 @@ systemctl status eap7-standalone.service        | log; flag=${PIPESTATUS[0]}
 ######################
 
 echo "Deploy an application" | log; flag=${PIPESTATUS[0]}
-echo "wget -O eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
-wget -O "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
+echo "curl -o eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
+curl -o "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
 if [ $flag != 0 ] ; then echo  "ERROR! Sample Application Download Failed" >&2 log; exit $flag; fi
 echo "cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/" | log; flag=${PIPESTATUS[0]}
 cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/ | log; flag=${PIPESTATUS[0]}

--- a/eap73-rhel8-payg-vmss/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap73-rhel8-payg-vmss/src/main/scripts/jbosseap-setup-redhat.sh
@@ -88,9 +88,9 @@ if [ $flag != 0 ] ; then echo  "ERROR! Pool Attach for JBoss EAP Failed" >&2 log
 #######################
 
 ####################### Install openjdk: is it needed? it should be installed with eap7.3
-echo "Install openjdk, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
-echo "sudo yum install java-1.8.0-openjdk wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}
-sudo yum install wget unzip vim git -y | log; flag=${PIPESTATUS[0]}#java-1.8.0-openjdk
+echo "Install openjdk, curl, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
+echo "sudo yum install java-1.8.0-openjdk curl wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}
+sudo yum install curl wget unzip vim git -y | log; flag=${PIPESTATUS[0]}#java-1.8.0-openjdk
 ####################### 
 
 
@@ -165,8 +165,8 @@ systemctl status eap7-standalone.service        | log; flag=${PIPESTATUS[0]}
 ######################
 
 echo "Deploy an application" | log; flag=${PIPESTATUS[0]}
-echo "wget -O eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
-wget -O "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
+echo "curl -o eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
+curl -o "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
 if [ $flag != 0 ] ; then echo  "ERROR! Sample Application Download Failed" >&2 log; exit $flag; fi
 echo "cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/" | log; flag=${PIPESTATUS[0]}
 cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/ | log; flag=${PIPESTATUS[0]}

--- a/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-setup-redhat.sh
@@ -108,9 +108,9 @@ fi
 
 
 ####################### Install openjdk: is it needed? it should be installed with eap7.4
-echo "Install openjdk, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
-echo "sudo yum install java-1.8.4-openjdk wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}
-sudo yum install wget unzip vim git -y | log; flag=${PIPESTATUS[0]}
+echo "Install openjdk, curl, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
+echo "sudo yum install java-1.8.4-openjdk curl wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}
+sudo yum install curl wget unzip vim git -y | log; flag=${PIPESTATUS[0]}
 ####################### 
 
 
@@ -188,8 +188,8 @@ systemctl status eap7-standalone.service        | log; flag=${PIPESTATUS[0]}
 ######################
 
 echo "Deploy an application" | log; flag=${PIPESTATUS[0]}
-echo "wget -O eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
-wget -O "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
+echo "curl -o eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
+curl -o "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
 if [ $flag != 0 ] ; then echo  "ERROR! Sample Application Download Failed" >&2 log; exit $flag; fi
 echo "cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/" | log; flag=${PIPESTATUS[0]}
 cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/ | log; flag=${PIPESTATUS[0]}

--- a/eap74-rhel8-byos-vmss/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-byos-vmss/src/main/scripts/jbosseap-setup-redhat.sh
@@ -99,9 +99,9 @@ fi
 #######################
 
 ####################### Install openjdk: is it needed? it should be installed with eap7.4
-echo "Install openjdk, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
-echo "sudo yum install java-1.8.4-openjdk wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}install.log
-sudo yum install wget unzip vim git -y | log; flag=${PIPESTATUS[0]} #java-1.8.4-openjdk
+echo "Install openjdk, curl, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
+echo "sudo yum install java-1.8.4-openjdk curl wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}install.log
+sudo yum install curl wget unzip vim git -y | log; flag=${PIPESTATUS[0]} #java-1.8.4-openjdk
 ####################### 
 
 
@@ -178,8 +178,8 @@ systemctl status eap7-standalone.service        | log; flag=${PIPESTATUS[0]}
 ######################
 
 echo "Deploy an application" | log; flag=${PIPESTATUS[0]}
-echo "wget -O eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
-wget -O "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
+echo "curl -o eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
+curl -o "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
 if [ $flag != 0 ] ; then echo  "ERROR! Sample Application Download Failed" >&2 log; exit $flag; fi
 echo "cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/" | log; flag=${PIPESTATUS[0]}
 cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/ | log; flag=${PIPESTATUS[0]} 

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
@@ -95,9 +95,9 @@ if [ $flag != 0 ] ; then echo  "ERROR! Pool Attach for JBoss EAP Failed" >&2 log
 #######################
 
 ####################### Install openjdk: is it needed? it should be installed with eap7.4
-echo "Install openjdk, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
-echo "sudo yum install java-1.8.4-openjdk wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}
-sudo yum install wget unzip vim git -y | log; flag=${PIPESTATUS[0]}#java-1.8.4-openjdk
+echo "Install openjdk, curl, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
+echo "sudo yum install java-1.8.4-openjdk curl wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}
+sudo yum install curl wget unzip vim git -y | log; flag=${PIPESTATUS[0]}#java-1.8.4-openjdk
 ####################### 
 
 ####################### Install JBoss EAP 7.4
@@ -171,8 +171,8 @@ systemctl status eap7-standalone.service        | log; flag=${PIPESTATUS[0]}
 ######################
 
 echo "Deploy an application" | log; flag=${PIPESTATUS[0]}
-echo "wget -O eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
-wget -O "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
+echo "curl -o eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
+curl -o "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
 if [ $flag != 0 ] ; then echo  "ERROR! Sample Application Download Failed" >&2 log; exit $flag; fi
 echo "cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/" | log; flag=${PIPESTATUS[0]}
 cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/ | log; flag=${PIPESTATUS[0]}

--- a/eap74-rhel8-payg-vmss/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-payg-vmss/src/main/scripts/jbosseap-setup-redhat.sh
@@ -88,9 +88,9 @@ if [ $flag != 0 ] ; then echo  "ERROR! Pool Attach for JBoss EAP Failed" >&2 log
 #######################
 
 ####################### Install openjdk: is it needed? it should be installed with eap7.4
-echo "Install openjdk, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
-echo "sudo yum install java-1.8.4-openjdk wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}
-sudo yum install wget unzip vim git -y | log; flag=${PIPESTATUS[0]}#java-1.8.4-openjdk
+echo "Install openjdk, curl, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
+echo "sudo yum install java-1.8.4-openjdk curl wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}
+sudo yum install curl wget unzip vim git -y | log; flag=${PIPESTATUS[0]}#java-1.8.4-openjdk
 ####################### 
 
 
@@ -165,8 +165,8 @@ systemctl status eap7-standalone.service        | log; flag=${PIPESTATUS[0]}
 ######################
 
 echo "Deploy an application" | log; flag=${PIPESTATUS[0]}
-echo "wget -O eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
-wget -O "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
+echo "curl -o eap-session-replication.war $fileUrl" | log; flag=${PIPESTATUS[0]}
+curl -o "eap-session-replication.war" "$fileUrl" | log; flag=${PIPESTATUS[0]}
 if [ $flag != 0 ] ; then echo  "ERROR! Sample Application Download Failed" >&2 log; exit $flag; fi
 echo "cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/" | log; flag=${PIPESTATUS[0]}
 cp ./eap-session-replication.war $EAP_HOME/wildfly/standalone/deployments/ | log; flag=${PIPESTATUS[0]}


### PR DESCRIPTION
A certificate in RHEL has expired and the fallback CA cert has an older algorithm that wget now considers insecure, which causes the sample app not to download. So rather than passing `--no-certificate-check`, switch to `curl`.