### PR TITLE
eap73-rhel84-standalone-payg-patch1

### DIFF
--- a/eap73-rhel8-payg/src/main/arm/createUiDefinition.json
+++ b/eap73-rhel8-payg/src/main/arm/createUiDefinition.json
@@ -248,6 +248,7 @@
             "storageNewOrExisting": "[steps('VirtualMachineConfig').storageAccountType.newOrExisting]",
             "storageAccountName": "[steps('VirtualMachineConfig').storageAccountType.name]",
             "storageAccountType": "[steps('VirtualMachineConfig').storageAccountType.type]",
+            "storageAccountKind": "[steps('VirtualMachineConfig').storageAccountType.kind]",
             "storageAccountResourceGroupName": "[steps('VirtualMachineConfig').storageAccountType.resourceGroup]",
 
             "jbossEAPUserName": "[steps('jbossEAPSettings').jbossEAPUserName]",


### PR DESCRIPTION
Fixed the storage kind issue. Now user can select "StorageV1 or StorageV2" as per desire.