### PR TITLE
Add artifact build support for eap74-rhel8-payg-multivm

### DIFF
--- a/generateOffers.sh
+++ b/generateOffers.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-OFFER_PATH_PATTERN="eap7*"
+OFFER_PATH_PATTERN="eap74*"
 
 setup_colors() {
   NOFORMAT='\033[0m' RED='\033[0;31m' GREEN='\033[0;32m' ORANGE='\033[0;33m' BLUE='\033[0;34m' PURPLE='\033[0;35m' CYAN='\033[0;36m' YELLOW='\033[1;33m'
@@ -18,6 +18,10 @@ for d in */ ; do
     folderName=$(basename $d)
     if [[ $folderName == $OFFER_PATH_PATTERN ]]; then
         msg "${YELLOW}matched folder name: $folderName. ${NOFORMAT}"
-        mvn -Ptemplate-validation-tests clean install -f $folderName/pom.xml
+        if [[ $folderName == "eap74-rhel8-payg-multivm" ]]; then
+          mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -f $folderName/pom.xml
+        else
+          mvn -Ptemplate-validation-tests clean install -f $folderName/pom.xml
+        fi
     fi
 done


### PR DESCRIPTION
#82 

Change:

* `/eap74-rhel8-payg-multivm` is upgraded to use Bicep so it needs a different way to build the artifact.
* `/eap74-rhel8-payg-multivm` is still excluded in `validateOffers.sh` because:
    * [arm-ttk only supports ARM templates](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/test-toolkit)
    * Bicep linter is a [required feature](https://github.com/Azure/bicep/issues/2811) not provided for now, and [current walk around](https://docs.microsoft.com/en-us/azure/azure-resource-manager/bicep/linter#use-in-bicep-cli) is to run `bicep build` but it generates .json template files