### PR TITLE
Support 'Register hosts to existing Satellite server' for eap74-rhel8-payg-multivm

### DIFF
--- a/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
@@ -567,7 +567,7 @@
             "rhsmPassword": "[steps('jbossEAPSettings').rhsmPassword]",
             "rhsmPoolEAP": "[steps('jbossEAPSettings').rhsmPoolEAP]",
             "identity": "[steps('jbossEAPSettings').identity]",
-            "connectSatellite": "[steps('VirtualMachineConfig').connectSatellite]",
+            "connectSatellite": "[steps('satelliteServerSettings').connectSatellite]",
             "satelliteVmId": "[steps('satelliteServerSettings').satelliteServerVmSelector.id]",
             "satelliteActivationKey": "[steps('satelliteServerSettings').satelliteActivationKey]",
             "satelliteOrgName": "[steps('satelliteServerSettings').satelliteOrgName]",

--- a/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
@@ -448,7 +448,93 @@
                         }
                     }
                 ]
-            }
+            },
+            {
+                "name": "satelliteServerSettings",
+                "label": "Satellite Server Settings",
+                "subLabel": {
+                    "preValidation": "Provide the settings for Satellite Server registration",
+                    "postValidation": "Done"
+                },
+                "bladeTitle": "Satellite Server Settings",
+                "elements": [
+                    {
+                        "name": "connectToSatelliteServer",
+                        "type": "Microsoft.Common.TextBlock",
+                        "visible": true,
+                        "options": {
+                            "text": "Selecting 'Yes' here will cause the template to register JBoss EAP hosts to an existing Red Hat Satellite Server. Further configuration may be necessary after deployment.",
+                            "link": {
+                                "label": "Learn more",
+                                "uri": "https://access.redhat.com/products/red-hat-satellite"
+                            }
+                        }
+                    },
+                    {
+                        "name": "connectSatellite",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Connect to an existing Red Hat Satellite Server?",
+                        "defaultValue": "No",
+                        "toolTip": "Select 'Yes' to register JBoss EAP hosts created in preview step to an existing Red Hat.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": true
+                                },
+                                {
+                                    "label": "No",
+                                    "value": false
+                                }
+                            ],
+                            "required": false
+                        }
+                    },
+					{
+						"name": "satelliteServerVmSelector",
+						"type": "Microsoft.Solutions.ResourceSelector",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+						"label": "Select the Virtual Machine has Red Hat Satellite Server running on it.",
+						"resourceType": "Microsoft.Compute/virtualMachines",
+						"options": {
+							"filter": {
+								"subscription": "onBasics",
+								"location": "onBasics"
+							}
+						}
+					},
+                    {
+                        "name": "satelliteActivationKey",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+                        "label": "The template will need the activation key to register the JBoss EAP host to the Red Hat Satellite server.",
+                        "toolTip": "Activation key",
+                        "constraints": {
+                            "required": true
+                        }
+                    },
+                    {
+                        "name": "satelliteOrgName",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+                        "label": "The template will need the Organization name to register the JBoss EAP host to the Red Hat Satellite server.",
+                        "toolTip": "Organization name",
+                        "constraints": {
+                            "required": true
+                        }
+                    },
+                    {
+                        "name": "satelliteFqdn",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+                        "label": "The template will need the FQDN of Satellite Server virtual machine.",
+                        "toolTip": "FQDN of Satellite Sever VM",
+                        "constraints": {
+                            "required": true
+                        }
+                    }
+				]
+			}
         ],
         "outputs": {
             "location": "[location()]",
@@ -480,7 +566,12 @@
             "rhsmUserName": "[steps('jbossEAPSettings').rhsmUserName]",
             "rhsmPassword": "[steps('jbossEAPSettings').rhsmPassword]",
             "rhsmPoolEAP": "[steps('jbossEAPSettings').rhsmPoolEAP]",
-            "identity": "[steps('jbossEAPSettings').identity]"
+            "identity": "[steps('jbossEAPSettings').identity]",
+            "connectSatellite": "[steps('VirtualMachineConfig').connectSatellite]",
+            "satelliteVmId": "[steps('satelliteServerSettings').satelliteServerVmSelector.id]",
+            "satelliteActivationKey": "[steps('satelliteServerSettings').satelliteActivationKey]",
+            "satelliteOrgName": "[steps('satelliteServerSettings').satelliteOrgName]",
+            "satelliteFqdn": "[steps('satelliteServerSettings').satelliteFqdn]"
         }
     }
 }

--- a/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
@@ -495,6 +495,7 @@
 						"type": "Microsoft.Solutions.ResourceSelector",
                         "visible": "[steps('satelliteServerSettings').connectSatellite]",
 						"label": "Select the Virtual Machine has Red Hat Satellite Server running on it.",
+                        "toolTip": "Select Satellite Server VM",
 						"resourceType": "Microsoft.Compute/virtualMachines",
 						"options": {
 							"filter": {
@@ -510,7 +511,9 @@
                         "label": "The template will need the activation key to register the JBoss EAP host to the Red Hat Satellite server.",
                         "toolTip": "Activation key",
                         "constraints": {
-                            "required": true
+                            "required": true,
+                            "regex": "^.{1,}$",
+                            "validationMessage": "Cannot be empty."
                         }
                     },
                     {
@@ -520,7 +523,9 @@
                         "label": "The template will need the Organization name to register the JBoss EAP host to the Red Hat Satellite server.",
                         "toolTip": "Organization name",
                         "constraints": {
-                            "required": true
+                            "required": true,
+                            "regex": "^.{1,}$",
+                            "validationMessage": "Cannot be empty."
                         }
                     },
                     {
@@ -530,7 +535,9 @@
                         "label": "The template will need the FQDN of Satellite Server virtual machine.",
                         "toolTip": "FQDN of Satellite Sever VM",
                         "constraints": {
-                            "required": true
+                            "required": true,
+                            "regex": "^.{1,}$",
+                            "validationMessage": "Cannot be empty."
                         }
                     }
 				]

--- a/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
@@ -109,6 +109,14 @@
                         "count": "1"
                     },
                     {
+                        "name": "vnetInfo",
+                        "type": "Microsoft.Common.InfoBox",
+                        "options": {
+                            "icon": "Info",
+                            "text": "When creating a new virtual network, the subnet's address prefix is calculated automatically based on the virtual network's address prefix. When using an existing virtual network, a minimum virtual network size of /28 and a minimum subnet size of /29 are required. Additionally, the subnet must have adequate available addresses for the server setup."
+                        }
+                    },
+                    {
                         "name": "virtualNetwork",
                         "type": "Microsoft.Network.VirtualNetworkCombo",
                         "label": {
@@ -121,7 +129,7 @@
                         },
                         "defaultValue": {
                             "name": "VirtualNetwork",
-                            "addressPrefixSize": "/16"
+                            "addressPrefixSize": "/28"
                         },
                         "constraints": {
                             "minAddressPrefixSize": "/28"
@@ -131,11 +139,11 @@
                                 "label": "Subnet",
                                 "defaultValue": {
                                     "name": "Subnet-1",
-                                    "addressPrefixSize": "/24"
+                                    "addressPrefixSize": "/28"
                                 },
                                 "constraints": {
                                     "minAddressPrefixSize": "/29",
-                                    "minAddressCount": 2,
+                                    "minAddressCount": "[add(int(steps('VirtualMachineConfig').numberOfInstances), 1)]",
                                     "requireContiguousAddresses": false
                                 }
                             }

--- a/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
@@ -121,7 +121,7 @@
                         },
                         "defaultValue": {
                             "name": "VirtualNetwork",
-                            "addressPrefixSize": "/28"
+                            "addressPrefixSize": "/16"
                         },
                         "constraints": {
                             "minAddressPrefixSize": "/28"
@@ -131,7 +131,7 @@
                                 "label": "Subnet",
                                 "defaultValue": {
                                     "name": "Subnet-1",
-                                    "addressPrefixSize": "/29"
+                                    "addressPrefixSize": "/24"
                                 },
                                 "constraints": {
                                     "minAddressPrefixSize": "/29",
@@ -353,8 +353,8 @@
                         "name": "satelliteFqdn",
                         "type": "Microsoft.Common.TextBox",
                         "visible": "[steps('satelliteServerSettings').connectSatellite]",
-                        "label": "The template will need the FQDN of Satellite Server virtual machine.",
-                        "toolTip": "FQDN of Satellite Sever VM",
+                        "label": "The template will need the Fully Qualified Domain Name of Satellite Server virtual machine.",
+                        "toolTip": "Fully Qualified Domain Name of Satellite Sever VM",
                         "constraints": {
                             "required": true,
                             "regex": "^.{1,}$",

--- a/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
@@ -568,7 +568,7 @@
             "rhsmPoolEAP": "[steps('jbossEAPSettings').rhsmPoolEAP]",
             "identity": "[steps('jbossEAPSettings').identity]",
             "connectSatellite": "[steps('satelliteServerSettings').connectSatellite]",
-            "satelliteVmId": "[steps('satelliteServerSettings').satelliteServerVmSelector.id]",
+            "satelliteVmResourceId": "[steps('satelliteServerSettings').satelliteServerVmSelector.id]",
             "satelliteActivationKey": "[steps('satelliteServerSettings').satelliteActivationKey]",
             "satelliteOrgName": "[steps('satelliteServerSettings').satelliteOrgName]",
             "satelliteFqdn": "[steps('satelliteServerSettings').satelliteFqdn]"

--- a/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
@@ -283,6 +283,86 @@
 					}
                 ]
             },
+			
+            {
+                "name": "satelliteServerSettings",
+                "label": "Satellite Server Settings",
+                "subLabel": {
+                    "preValidation": "Provide the settings for Satellite Server registration",
+                    "postValidation": "Done"
+                },
+                "bladeTitle": "Satellite Server Settings",
+                "elements": [
+                    {
+                        "name": "connectToSatelliteServer",
+                        "type": "Microsoft.Common.TextBlock",
+                        "visible": true,
+                        "options": {
+                            "text": "Selecting 'Yes' here will cause the template to register JBoss EAP hosts to an existing Red Hat Satellite Server. Further configuration may be necessary after deployment.",
+                            "link": {
+                                "label": "Learn more",
+                                "uri": "https://access.redhat.com/products/red-hat-satellite"
+                            }
+                        }
+                    },
+                    {
+                        "name": "connectSatellite",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Connect to an existing Red Hat Satellite Server?",
+                        "defaultValue": "No",
+                        "toolTip": "Select 'Yes' to register JBoss EAP hosts created in preview step to an existing Red Hat.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": true
+                                },
+                                {
+                                    "label": "No",
+                                    "value": false
+                                }
+                            ],
+                            "required": false
+                        }
+                    },
+                    {
+                        "name": "satelliteActivationKey",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+                        "label": "The template will need the activation key to register the JBoss EAP host to the Red Hat Satellite server.",
+                        "toolTip": "Activation key",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^.{1,}$",
+                            "validationMessage": "Cannot be empty."
+                        }
+                    },
+                    {
+                        "name": "satelliteOrgName",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+                        "label": "The template will need the Organization name to register the JBoss EAP host to the Red Hat Satellite server.",
+                        "toolTip": "Organization name",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^.{1,}$",
+                            "validationMessage": "Cannot be empty."
+                        }
+                    },
+                    {
+                        "name": "satelliteFqdn",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+                        "label": "The template will need the FQDN of Satellite Server virtual machine.",
+                        "toolTip": "FQDN of Satellite Sever VM",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^.{1,}$",
+                            "validationMessage": "Cannot be empty."
+                        }
+                    }
+				]
+			},
             {
                 "name": "jbossEAPSettings",
                 "label": "JBoss EAP Settings",
@@ -387,6 +467,7 @@
                     {
                         "name": "rhsmUserName",
                         "type": "Microsoft.Common.TextBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
                         "label": "RHSM username",
                         "constraints": {
                             "required": true,
@@ -398,11 +479,11 @@
                     {
                         "name": "rhsmPassword",
                         "type": "Microsoft.Common.PasswordBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
                         "label": {
                             "password": "RHSM password",
                             "confirmPassword": "Confirm password"
                         },
-                        "visible": true,
                         "toolTip": "Provide Password for  Red Hat subscription Manager",
                         "options": {
                             "hideConfirmation": false
@@ -414,6 +495,7 @@
                     {
                         "name": "rhsmPoolEAP",
                         "type": "Microsoft.Common.TextBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
                         "label": "RHSM Pool ID with EAP entitlement",
                         "toolTip": "Red Hat Subscription Manager Pool ID (Should have EAP entitlement)",
                         "constraints": {
@@ -448,100 +530,7 @@
                         }
                     }
                 ]
-            },
-            {
-                "name": "satelliteServerSettings",
-                "label": "Satellite Server Settings",
-                "subLabel": {
-                    "preValidation": "Provide the settings for Satellite Server registration",
-                    "postValidation": "Done"
-                },
-                "bladeTitle": "Satellite Server Settings",
-                "elements": [
-                    {
-                        "name": "connectToSatelliteServer",
-                        "type": "Microsoft.Common.TextBlock",
-                        "visible": true,
-                        "options": {
-                            "text": "Selecting 'Yes' here will cause the template to register JBoss EAP hosts to an existing Red Hat Satellite Server. Further configuration may be necessary after deployment.",
-                            "link": {
-                                "label": "Learn more",
-                                "uri": "https://access.redhat.com/products/red-hat-satellite"
-                            }
-                        }
-                    },
-                    {
-                        "name": "connectSatellite",
-                        "type": "Microsoft.Common.OptionsGroup",
-                        "label": "Connect to an existing Red Hat Satellite Server?",
-                        "defaultValue": "No",
-                        "toolTip": "Select 'Yes' to register JBoss EAP hosts created in preview step to an existing Red Hat.",
-                        "constraints": {
-                            "allowedValues": [
-                                {
-                                    "label": "Yes",
-                                    "value": true
-                                },
-                                {
-                                    "label": "No",
-                                    "value": false
-                                }
-                            ],
-                            "required": false
-                        }
-                    },
-					{
-						"name": "satelliteServerVmSelector",
-						"type": "Microsoft.Solutions.ResourceSelector",
-                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
-						"label": "Select the Virtual Machine has Red Hat Satellite Server running on it.",
-                        "toolTip": "Select Satellite Server VM",
-						"resourceType": "Microsoft.Compute/virtualMachines",
-						"options": {
-							"filter": {
-								"subscription": "onBasics",
-								"location": "onBasics"
-							}
-						}
-					},
-                    {
-                        "name": "satelliteActivationKey",
-                        "type": "Microsoft.Common.TextBox",
-                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
-                        "label": "The template will need the activation key to register the JBoss EAP host to the Red Hat Satellite server.",
-                        "toolTip": "Activation key",
-                        "constraints": {
-                            "required": true,
-                            "regex": "^.{1,}$",
-                            "validationMessage": "Cannot be empty."
-                        }
-                    },
-                    {
-                        "name": "satelliteOrgName",
-                        "type": "Microsoft.Common.TextBox",
-                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
-                        "label": "The template will need the Organization name to register the JBoss EAP host to the Red Hat Satellite server.",
-                        "toolTip": "Organization name",
-                        "constraints": {
-                            "required": true,
-                            "regex": "^.{1,}$",
-                            "validationMessage": "Cannot be empty."
-                        }
-                    },
-                    {
-                        "name": "satelliteFqdn",
-                        "type": "Microsoft.Common.TextBox",
-                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
-                        "label": "The template will need the FQDN of Satellite Server virtual machine.",
-                        "toolTip": "FQDN of Satellite Sever VM",
-                        "constraints": {
-                            "required": true,
-                            "regex": "^.{1,}$",
-                            "validationMessage": "Cannot be empty."
-                        }
-                    }
-				]
-			}
+            }
         ],
         "outputs": {
             "location": "[location()]",
@@ -575,7 +564,6 @@
             "rhsmPoolEAP": "[steps('jbossEAPSettings').rhsmPoolEAP]",
             "identity": "[steps('jbossEAPSettings').identity]",
             "connectSatellite": "[steps('satelliteServerSettings').connectSatellite]",
-            "satelliteVmResourceId": "[steps('satelliteServerSettings').satelliteServerVmSelector.id]",
             "satelliteActivationKey": "[steps('satelliteServerSettings').satelliteActivationKey]",
             "satelliteOrgName": "[steps('satelliteServerSettings').satelliteOrgName]",
             "satelliteFqdn": "[steps('satelliteServerSettings').satelliteFqdn]"

--- a/eap74-rhel8-payg-multivm/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-payg-multivm/src/main/bicep/mainTemplate.bicep
@@ -50,6 +50,10 @@ param numberOfServerInstances int = 2
 param enableLoadBalancer string = 'enable'
 
 @description('Managed domain mode or standalone mode')
+@allowed([
+  'standalone'
+  'managed-domain'
+])
 param operatingMode string = 'managed-domain'
 
 @description('Name of the availability set')
@@ -125,6 +129,21 @@ param artifactsLocationSasToken string = ''
 @description('An user assigned managed identity. Make sure the identity has permission to create/update/delete/list Azure resources.')
 param identity object
 
+@description('Connect to an existing Red Hat Satellite Server.')
+var connectSatellite = 'false'
+
+@description('Red Hat Satellite Server VM resource ID.')
+var satelliteVmResourceId = ''
+
+@description('Red Hat Satellite Server activation key.')
+var satelliteActivationKey = ''
+
+@description('Red Hat Satellite Server organization name.')
+var satelliteOrgName = ''
+
+@description('Red Hat Satellite Server VM FQDN name.')
+var satelliteFqdn = ''
+
 var name_managedDomain = 'managed-domain'
 var name_fileshare = 'jbossshare'
 var containerName = 'eapblobcontainer'
@@ -163,7 +182,7 @@ var scriptFolder = 'scripts'
 var fileFolder = 'bin'
 var fileToBeDownloaded = 'eap-session-replication.war'
 var scriptArgs = '-a "${uri(artifactsLocation, '.')}" -t "${empty(artifactsLocationSasToken) ? '?' : 'artifactsLocationSasToken'}" -p ${fileFolder} -f ${fileToBeDownloaded} -s ${scriptFolder}'
-var const_arguments = '${scriptArgs} ${jbossEAPUserName} ${base64(jbossEAPPassword)} ${rhsmUserName} ${base64(rhsmPassword)} ${rhsmPoolEAP} ${eapStorageAccountName} ${containerName} ${resourceGroup().name} ${numberOfInstances} ${vmName_var} ${numberOfServerInstances} ${operatingMode} ${virtualNetworkNewOrExisting}'
+var const_arguments = '${scriptArgs} ${jbossEAPUserName} ${base64(jbossEAPPassword)} ${rhsmUserName} ${base64(rhsmPassword)} ${rhsmPoolEAP} ${eapStorageAccountName} ${containerName} ${resourceGroup().name} ${numberOfInstances} ${vmName_var} ${numberOfServerInstances} ${operatingMode} ${virtualNetworkNewOrExisting} ${connectSatellite} ${satelliteVmResourceId} ${satelliteActivationKey} ${satelliteOrgName} ${satelliteFqdn}'
 var const_scriptLocation = uri(artifactsLocation, 'scripts/')
 var const_setupJBossScript = 'jbosseap-setup-redhat.sh'
 var const_setupDomainMasterScript = 'jbosseap-setup-master.sh'
@@ -380,31 +399,6 @@ resource jbossEAPSetup 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
     eapStorageAccount
   ]
 }
-
-// resource vmName_jbosseap_setup_extension 'Microsoft.Compute/virtualMachines/extensions@2021-03-01' = [for i in range(0, numberOfInstances): {
-//   name: '${vmName_var}${i}/jbosseap-setup-extension-${i}'
-//   location: location
-//   tags: {
-//     QuickstartName: 'JBoss EAP on RHEL (clustered, multi-VM)'
-//   }
-//   properties: {
-//     publisher: 'Microsoft.Azure.Extensions'
-//     type: 'CustomScript'
-//     typeHandlerVersion: '2.0'
-//     autoUpgradeMinorVersion: true
-//     settings: {
-//       fileUris: [
-//         uri(artifactsLocation, 'scripts/jbosseap-setup-redhat.sh${artifactsLocationSasToken}')
-//       ]
-//     }
-//     protectedSettings: {
-//       commandToExecute: 'sh jbosseap-setup-redhat.sh ${scriptArgs} \'${jbossEAPUserName}\' \'${jbossEAPPassword}\' \'${rhsmUserName}\' \'${rhsmPassword}\' \'${rhsmPoolEAP}\' \'${eapStorageAccountName_var}\' \'${containerName}\' \'${base64(listKeys(eapStorageAccountName.id, '2021-04-01').keys[0].value)}\''
-//     }
-//   }
-//   dependsOn: [
-//     resourceId('Microsoft.Compute/virtualMachines', concat(vmName_var, i))
-//   ]
-// }]
 
 resource loadBalancersName 'Microsoft.Network/loadBalancers@2020-11-01' = if (const_enableLoadBalancer) {
   name: loadBalancersName_var

--- a/eap74-rhel8-payg-multivm/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-payg-multivm/src/main/bicep/mainTemplate.bicep
@@ -130,19 +130,19 @@ param artifactsLocationSasToken string = ''
 param identity object
 
 @description('Connect to an existing Red Hat Satellite Server.')
-var connectSatellite = 'false'
+param connectSatellite bool = false
 
 @description('Red Hat Satellite Server VM resource ID.')
-var satelliteVmResourceId = ''
+param satelliteVmResourceId string = ''
 
 @description('Red Hat Satellite Server activation key.')
-var satelliteActivationKey = ''
+param satelliteActivationKey string = ''
 
 @description('Red Hat Satellite Server organization name.')
-var satelliteOrgName = ''
+param satelliteOrgName string = ''
 
 @description('Red Hat Satellite Server VM FQDN name.')
-var satelliteFqdn = ''
+param satelliteFqdn string = ''
 
 var name_managedDomain = 'managed-domain'
 var name_fileshare = 'jbossshare'
@@ -182,7 +182,7 @@ var scriptFolder = 'scripts'
 var fileFolder = 'bin'
 var fileToBeDownloaded = 'eap-session-replication.war'
 var scriptArgs = '-a "${uri(artifactsLocation, '.')}" -t "${empty(artifactsLocationSasToken) ? '?' : 'artifactsLocationSasToken'}" -p ${fileFolder} -f ${fileToBeDownloaded} -s ${scriptFolder}'
-var const_arguments = '${scriptArgs} ${jbossEAPUserName} ${base64(jbossEAPPassword)} ${rhsmUserName} ${base64(rhsmPassword)} ${rhsmPoolEAP} ${eapStorageAccountName} ${containerName} ${resourceGroup().name} ${numberOfInstances} ${vmName_var} ${numberOfServerInstances} ${operatingMode} ${virtualNetworkNewOrExisting} ${connectSatellite} ${satelliteVmResourceId} ${satelliteActivationKey} ${satelliteOrgName} ${satelliteFqdn}'
+var const_arguments = '${scriptArgs} ${jbossEAPUserName} ${base64(jbossEAPPassword)} ${rhsmUserName} ${base64(rhsmPassword)} ${rhsmPoolEAP} ${eapStorageAccountName} ${containerName} ${resourceGroup().name} ${numberOfInstances} ${vmName_var} ${numberOfServerInstances} ${operatingMode} ${virtualNetworkNewOrExisting} ${bool('${connectSatellite}')} ${satelliteVmResourceId} ${satelliteActivationKey} ${satelliteOrgName} ${satelliteFqdn}'
 var const_scriptLocation = uri(artifactsLocation, 'scripts/')
 var const_setupJBossScript = 'jbosseap-setup-redhat.sh'
 var const_setupDomainMasterScript = 'jbosseap-setup-master.sh'

--- a/eap74-rhel8-payg-multivm/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-payg-multivm/src/main/bicep/mainTemplate.bicep
@@ -24,14 +24,14 @@ param jbossEAPUserName string
 param jbossEAPPassword string
 
 @description('User name for Red Hat subscription Manager')
-param rhsmUserName string
+param rhsmUserName string = newGuid()
 
 @description('Password for Red Hat subscription Manager')
 @secure()
-param rhsmPassword string
+param rhsmPassword string = newGuid()
 
 @description('Red Hat Subscription Manager Pool ID (Should have EAP entitlement)')
-param rhsmPoolEAP string
+param rhsmPoolEAP string = newGuid()
 
 @description('The size of the Virtual Machine')
 param vmSize string = 'Standard_DS2_v2'
@@ -132,9 +132,6 @@ param identity object
 @description('Connect to an existing Red Hat Satellite Server.')
 param connectSatellite bool = false
 
-@description('Red Hat Satellite Server VM resource ID.')
-param satelliteVmResourceId string = ''
-
 @description('Red Hat Satellite Server activation key.')
 param satelliteActivationKey string = ''
 
@@ -182,7 +179,7 @@ var scriptFolder = 'scripts'
 var fileFolder = 'bin'
 var fileToBeDownloaded = 'eap-session-replication.war'
 var scriptArgs = '-a "${uri(artifactsLocation, '.')}" -t "${empty(artifactsLocationSasToken) ? '?' : 'artifactsLocationSasToken'}" -p ${fileFolder} -f ${fileToBeDownloaded} -s ${scriptFolder}'
-var const_arguments = '${scriptArgs} ${jbossEAPUserName} ${base64(jbossEAPPassword)} ${rhsmUserName} ${base64(rhsmPassword)} ${rhsmPoolEAP} ${eapStorageAccountName} ${containerName} ${resourceGroup().name} ${numberOfInstances} ${vmName_var} ${numberOfServerInstances} ${operatingMode} ${virtualNetworkNewOrExisting} ${bool('${connectSatellite}')} ${satelliteVmResourceId} ${satelliteActivationKey} ${satelliteOrgName} ${satelliteFqdn}'
+var const_arguments = '${scriptArgs} ${jbossEAPUserName} ${base64(jbossEAPPassword)} ${rhsmUserName} ${base64(rhsmPassword)} ${rhsmPoolEAP} ${eapStorageAccountName} ${containerName} ${resourceGroup().name} ${numberOfInstances} ${vmName_var} ${numberOfServerInstances} ${operatingMode} ${virtualNetworkNewOrExisting} ${connectSatellite} ${base64(satelliteActivationKey)} ${base64(satelliteOrgName)} ${satelliteFqdn}'
 var const_scriptLocation = uri(artifactsLocation, 'scripts/')
 var const_setupJBossScript = 'jbosseap-setup-redhat.sh'
 var const_setupDomainMasterScript = 'jbosseap-setup-master.sh'

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-master.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-master.sh
@@ -247,17 +247,21 @@ $EAP_HOME/wildfly/bin/add-user.sh  -u $JBOSS_EAP_USER -p $JBOSS_EAP_PASSWORD -g 
 if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP management user configuration Failed" >&2 log; exit $flag;  fi
 
 # Satellite server configuration
-if [ "${CONNECT_SATELLITE}" == "true" ]; then
+echo "CONNECT_SATELLITE: ${CONNECT_SATELLITE}"
+if [[ "${CONNECT_SATELLITE,,}" == "true" ]]; then
     echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
 
-    echo "sudo sed -i "${SATELLITE_VM_PRIVATE_IP}  ${SATELLITE_VM_FQDN}" /etc/hosts" | log; flag=${PIPESTATUS[0]}
-    sudo sed -i "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" /etc/hosts | log; flag=${PIPESTATUS[0]}
+    echo "echo "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" | sudo tee -a /etc/hosts" | log; flag=${PIPESTATUS[0]}
+    echo "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" | sudo tee -a /etc/hosts | log; flag=${PIPESTATUS[0]}
 
     echo "sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm" | log; flag=${PIPESTATUS[0]}
     sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm | log; flag=${PIPESTATUS[0]}
 
-    echo "sudo subscription-manager register --org=/"${SATELLITE_ORG_NAME}/" --activationkey=/"${SATELLITE_ACTIVATION_KEY}/"" | log; flag=${PIPESTATUS[0]}
-    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY} | log; flag=${PIPESTATUS[0]}
+    echo "sudo subscription-manager clean" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager clean | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY} --force | log; flag=${PIPESTATUS[0]}
 fi
 
 # Seeing a race condition timing error so sleep to delay

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-master.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-master.sh
@@ -94,6 +94,11 @@ STORAGE_ACCOUNT_NAME=${14}
 CONTAINER_NAME=${15}
 STORAGE_ACCESS_KEY=${16}
 STORAGE_ACCOUNT_PRIVATE_IP=${17}
+CONNECT_SATELLITE=${18}
+SATELLITE_ACTIVATION_KEY=${19}
+SATELLITE_ORG_NAME=${20}
+SATELLITE_VM_FQDN=${21}
+SATELLITE_VM_PRIVATE_IP=${22}
 
 MOUNT_POINT_PATH=/mnt/jbossshare
 HOST_VM_IP=$(hostname -I)
@@ -237,6 +242,16 @@ echo "Configuring JBoss EAP management user..." | log; flag=${PIPESTATUS[0]}
 echo "$EAP_HOME/wildfly/bin/add-user.sh -u JBOSS_EAP_USER -p JBOSS_EAP_PASSWORD -g 'guest,mgmtgroup'" | log; flag=${PIPESTATUS[0]}
 $EAP_HOME/wildfly/bin/add-user.sh  -u $JBOSS_EAP_USER -p $JBOSS_EAP_PASSWORD -g 'guest,mgmtgroup' | log; flag=${PIPESTATUS[0]}
 if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP management user configuration Failed" >&2 log; exit $flag;  fi
+
+# Satellite server configuration
+if [ "${CONNECT_SATELLITE}" == "true" ]; then
+    echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
+    echo "sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm" | log; flag=${PIPESTATUS[0]}
+    sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm
+
+    echo "sudo subscription-manager register --org=/"${SATELLITE_ORG_NAME}/" --activationkey=/"${SATELLITE_ACTIVATION_KEY}/"" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}
+fi
 
 # Seeing a race condition timing error so sleep to delay
 sleep 20

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-master.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-master.sh
@@ -251,6 +251,9 @@ if [ "${CONNECT_SATELLITE}" == "true" ]; then
 
     echo "sudo subscription-manager register --org=/"${SATELLITE_ORG_NAME}/" --activationkey=/"${SATELLITE_ACTIVATION_KEY}/"" | log; flag=${PIPESTATUS[0]}
     sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}
+
+    echo "sudo sed -i "${SATELLITE_VM_PRIVATE_IP}  ${SATELLITE_VM_FQDN}" /etc/hosts"
+    sudo sed -i "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" /etc/hosts
 fi
 
 # Seeing a race condition timing error so sleep to delay

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-master.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-master.sh
@@ -101,9 +101,6 @@ SATELLITE_ORG_NAME_BASE64=${20}
 SATELLITE_ORG_NAME=$(echo $SATELLITE_ORG_NAME_BASE64 | base64 -d)
 SATELLITE_VM_FQDN=${21}
 
-echo "all prameters: "
-echo $@
-
 MOUNT_POINT_PATH=/mnt/jbossshare
 HOST_VM_IP=$(hostname -I)
 

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-master.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-master.sh
@@ -100,6 +100,9 @@ SATELLITE_ORG_NAME=${20}
 SATELLITE_VM_FQDN=${21}
 SATELLITE_VM_PRIVATE_IP=${22}
 
+echo "all prameters: "
+echo $@
+
 MOUNT_POINT_PATH=/mnt/jbossshare
 HOST_VM_IP=$(hostname -I)
 
@@ -246,14 +249,15 @@ if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP management user configuration F
 # Satellite server configuration
 if [ "${CONNECT_SATELLITE}" == "true" ]; then
     echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo sed -i "${SATELLITE_VM_PRIVATE_IP}  ${SATELLITE_VM_FQDN}" /etc/hosts" | log; flag=${PIPESTATUS[0]}
+    sudo sed -i "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" /etc/hosts | log; flag=${PIPESTATUS[0]}
+
     echo "sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm" | log; flag=${PIPESTATUS[0]}
-    sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm
+    sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm | log; flag=${PIPESTATUS[0]}
 
     echo "sudo subscription-manager register --org=/"${SATELLITE_ORG_NAME}/" --activationkey=/"${SATELLITE_ACTIVATION_KEY}/"" | log; flag=${PIPESTATUS[0]}
-    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}
-
-    echo "sudo sed -i "${SATELLITE_VM_PRIVATE_IP}  ${SATELLITE_VM_FQDN}" /etc/hosts"
-    sudo sed -i "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" /etc/hosts
+    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY} | log; flag=${PIPESTATUS[0]}
 fi
 
 # Seeing a race condition timing error so sleep to delay

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
@@ -62,7 +62,7 @@ echo "SCRIPT_LOCATION: ${SCRIPT_LOCATION}"
 
 # Satellite server
 SATELLITE_VM_PRIVATE_IP=''
-if [ "${CONNECT_SATELLITE}" == "true" ]; then
+if [[ "${CONNECT_SATELLITE,,}" == "true" ]]; then
     SATELLITE_VM_PRIVATE_IP=$(az vm list-ip-addresses --verbose --ids ${SATELLITE_VM_RESOURCE_ID} --query [0].virtualMachine.network.privateIpAddresses[0] --output tsv)
 
     echo "SATELLITE_VM_PRIVATE_IP: ${SATELLITE_VM_PRIVATE_IP}"

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
@@ -34,10 +34,9 @@ NUMBER_OF_SERVER_INSTANCE=${21}
 CONFIGURATION_MODE=${22}
 VNET_NEW_OR_EXISTING=${23}
 CONNECT_SATELLITE=${24}
-SATELLITE_VM_RESOURCE_ID=${25}
-SATELLITE_ACTIVATION_KEY=${26}
-SATELLITE_ORG_NAME=${27}
-SATELLITE_VM_FQDN=${28}
+SATELLITE_ACTIVATION_KEY_BASE64=${25}
+SATELLITE_ORG_NAME_BASE64=${26}
+SATELLITE_VM_FQDN=${27}
 
 echo "all prameters: "
 echo $@
@@ -60,14 +59,6 @@ SCRIPT_LOCATION=${artifactsLocation}${pathToScript}
 
 echo "SCRIPT_LOCATION: ${SCRIPT_LOCATION}"
 
-# Satellite server
-SATELLITE_VM_PRIVATE_IP=''
-if [[ "${CONNECT_SATELLITE,,}" == "true" ]]; then
-    SATELLITE_VM_PRIVATE_IP=$(az vm list-ip-addresses --verbose --ids ${SATELLITE_VM_RESOURCE_ID} --query [0].virtualMachine.network.privateIpAddresses[0] --output tsv)
-
-    echo "SATELLITE_VM_PRIVATE_IP: ${SATELLITE_VM_PRIVATE_IP}"
-fi
-
 
 if [ "${CONFIGURATION_MODE}" != "managed-domain" ]; then
     # Configure standalone host
@@ -79,7 +70,7 @@ if [ "${CONFIGURATION_MODE}" != "managed-domain" ]; then
         --publisher Microsoft.Azure.Extensions \
         --version 2.0 \
         --settings "{\"fileUris\": [\"${SCRIPT_LOCATION}/jbosseap-setup-standalone.sh\"]}" \
-        --protected-settings "{\"commandToExecute\":\"bash jbosseap-setup-standalone.sh -a $artifactsLocation -t $token -p $pathToFile -f $fileToDownload ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY} ${SATELLITE_ORG_NAME} ${SATELLITE_VM_FQDN} ${SATELLITE_VM_PRIVATE_IP} \"}"
+        --protected-settings "{\"commandToExecute\":\"bash jbosseap-setup-standalone.sh -a $artifactsLocation -t $token -p $pathToFile -f $fileToDownload ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY_BASE64} ${SATELLITE_ORG_NAME_BASE64} ${SATELLITE_VM_FQDN} \"}"
         echo $?
         echo "standalone ${VM_NAME_PREFIX}${i} extension execution completed"
     done
@@ -93,7 +84,7 @@ else
         --publisher Microsoft.Azure.Extensions \
         --version 2.0 \
         --settings "{\"fileUris\": [\"${SCRIPT_LOCATION}/jbosseap-setup-master.sh\"]}" \
-        --protected-settings "{\"commandToExecute\":\"bash jbosseap-setup-master.sh -a $artifactsLocation -t $token -p $pathToFile -f $fileToDownload ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${privateEndpointIp} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY} ${SATELLITE_ORG_NAME} ${SATELLITE_VM_FQDN} ${SATELLITE_VM_PRIVATE_IP} \"}"
+        --protected-settings "{\"commandToExecute\":\"bash jbosseap-setup-master.sh -a $artifactsLocation -t $token -p $pathToFile -f $fileToDownload ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${privateEndpointIp} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY_BASE64} ${SATELLITE_ORG_NAME_BASE64} ${SATELLITE_VM_FQDN} \"}"
     # error exception
     echo $?
     echo "Domain controller VM extension execution completed"
@@ -106,7 +97,7 @@ else
         --publisher Microsoft.Azure.Extensions \
         --version 2.0 \
         --settings "{\"fileUris\": [\"${SCRIPT_LOCATION}/jbosseap-setup-slave.sh\"]}" \
-        --protected-settings "{\"commandToExecute\":\"bash jbosseap-setup-slave.sh -a $artifactsLocation -t $token -p $pathToFile -f $fileToDownload ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${privateEndpointIp} ${DOMAIN_CONTROLLER_PRIVATE_IP} ${NUMBER_OF_SERVER_INSTANCE} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY} ${SATELLITE_ORG_NAME} ${SATELLITE_VM_FQDN} ${SATELLITE_VM_PRIVATE_IP} \"}"
+        --protected-settings "{\"commandToExecute\":\"bash jbosseap-setup-slave.sh -a $artifactsLocation -t $token -p $pathToFile -f $fileToDownload ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${privateEndpointIp} ${DOMAIN_CONTROLLER_PRIVATE_IP} ${NUMBER_OF_SERVER_INSTANCE} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY_BASE64} ${SATELLITE_ORG_NAME_BASE64} ${SATELLITE_VM_FQDN} \"}"
         echo $?
         echo "Slave ${VM_NAME_PREFIX}${i} extension execution completed"
     done

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
@@ -38,9 +38,6 @@ SATELLITE_ACTIVATION_KEY_BASE64=${25}
 SATELLITE_ORG_NAME_BASE64=${26}
 SATELLITE_VM_FQDN=${27}
 
-echo "all prameters: "
-echo $@
-
 # Get storage account sas token
 STORAGE_ACCESS_KEY=$(az storage account keys list --verbose --account-name "${STORAGE_ACCOUNT_NAME}" --query [0].value --output tsv)
 

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
@@ -33,6 +33,11 @@ VM_NAME_PREFIX=${20}
 NUMBER_OF_SERVER_INSTANCE=${21}
 CONFIGURATION_MODE=${22}
 VNET_NEW_OR_EXISTING=${23}
+CONNECT_SATELLITE=${24}
+SATELLITE_VM_RESOURCE_ID=${25}
+SATELLITE_ACTIVATION_KEY=${26}
+SATELLITE_ORG_NAME=${27}
+SATELLITE_VM_FQDN=${28}
 
 # Get storage account sas token
 STORAGE_ACCESS_KEY=$(az storage account keys list --verbose --account-name "${STORAGE_ACCOUNT_NAME}" --query [0].value --output tsv)
@@ -52,8 +57,16 @@ SCRIPT_LOCATION=${artifactsLocation}${pathToScript}
 
 echo "SCRIPT_LOCATION: ${SCRIPT_LOCATION}"
 
+# Satellite server
+SATELLITE_VM_PRIVATE_IP=''
+if [ "CONNECT_SATELLITE" == "true" ]; then
+    SATELLITE_VM_PRIVATE_IP=$(az vm list-ip-addresses --verbose --ids ${SATELLITE_VM_RESOURCE_ID} --query [0].virtualMachine.network.privateIpAddresses[0] --output tsv)
 
-if [[ "${CONFIGURATION_MODE,,}" != "managed-domain" ]]; then
+    echo "SATELLITE_VM_PRIVATE_IP: ${SATELLITE_VM_PRIVATE_IP}"
+fi
+
+
+if [ "${CONFIGURATION_MODE}" != "managed-domain" ]; then
     # Configure standalone host
     for ((i = 0; i < NUMBER_OF_INSTANCE; i++)); do
         echo "Configure standalone host: ${VM_NAME_PREFIX}${i}"
@@ -63,7 +76,7 @@ if [[ "${CONFIGURATION_MODE,,}" != "managed-domain" ]]; then
         --publisher Microsoft.Azure.Extensions \
         --version 2.0 \
         --settings "{\"fileUris\": [\"${SCRIPT_LOCATION}/jbosseap-setup-standalone.sh\"]}" \
-        --protected-settings "{\"commandToExecute\":\"bash jbosseap-setup-standalone.sh -a $artifactsLocation -t $token -p $pathToFile -f $fileToDownload ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY}\"}"
+        --protected-settings "{\"commandToExecute\":\"bash jbosseap-setup-standalone.sh -a $artifactsLocation -t $token -p $pathToFile -f $fileToDownload ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY} ${SATELLITE_ORG_NAME} ${SATELLITE_VM_FQDN} ${SATELLITE_VM_PRIVATE_IP} \"}"
         echo $?
         echo "standalone ${VM_NAME_PREFIX}${i} extension execution completed"
     done
@@ -77,7 +90,7 @@ else
         --publisher Microsoft.Azure.Extensions \
         --version 2.0 \
         --settings "{\"fileUris\": [\"${SCRIPT_LOCATION}/jbosseap-setup-master.sh\"]}" \
-        --protected-settings "{\"commandToExecute\":\"bash jbosseap-setup-master.sh -a $artifactsLocation -t $token -p $pathToFile -f $fileToDownload ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${privateEndpointIp}\"}"
+        --protected-settings "{\"commandToExecute\":\"bash jbosseap-setup-master.sh -a $artifactsLocation -t $token -p $pathToFile -f $fileToDownload ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${privateEndpointIp} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY} ${SATELLITE_ORG_NAME} ${SATELLITE_VM_FQDN} ${SATELLITE_VM_PRIVATE_IP} \"}"
     # error exception
     echo $?
     echo "Domain controller VM extension execution completed"
@@ -90,7 +103,7 @@ else
         --publisher Microsoft.Azure.Extensions \
         --version 2.0 \
         --settings "{\"fileUris\": [\"${SCRIPT_LOCATION}/jbosseap-setup-slave.sh\"]}" \
-        --protected-settings "{\"commandToExecute\":\"bash jbosseap-setup-slave.sh -a $artifactsLocation -t $token -p $pathToFile -f $fileToDownload ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${privateEndpointIp} ${DOMAIN_CONTROLLER_PRIVATE_IP} ${NUMBER_OF_SERVER_INSTANCE}\"}"
+        --protected-settings "{\"commandToExecute\":\"bash jbosseap-setup-slave.sh -a $artifactsLocation -t $token -p $pathToFile -f $fileToDownload ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${privateEndpointIp} ${DOMAIN_CONTROLLER_PRIVATE_IP} ${NUMBER_OF_SERVER_INSTANCE} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY} ${SATELLITE_ORG_NAME} ${SATELLITE_VM_FQDN} ${SATELLITE_VM_PRIVATE_IP} \"}"
         echo $?
         echo "Slave ${VM_NAME_PREFIX}${i} extension execution completed"
     done

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
@@ -39,6 +39,9 @@ SATELLITE_ACTIVATION_KEY=${26}
 SATELLITE_ORG_NAME=${27}
 SATELLITE_VM_FQDN=${28}
 
+echo "all prameters: "
+echo $@
+
 # Get storage account sas token
 STORAGE_ACCESS_KEY=$(az storage account keys list --verbose --account-name "${STORAGE_ACCOUNT_NAME}" --query [0].value --output tsv)
 
@@ -59,7 +62,7 @@ echo "SCRIPT_LOCATION: ${SCRIPT_LOCATION}"
 
 # Satellite server
 SATELLITE_VM_PRIVATE_IP=''
-if [ "CONNECT_SATELLITE" == "true" ]; then
+if [ "${CONNECT_SATELLITE}" == "true" ]; then
     SATELLITE_VM_PRIVATE_IP=$(az vm list-ip-addresses --verbose --ids ${SATELLITE_VM_RESOURCE_ID} --query [0].virtualMachine.network.privateIpAddresses[0] --output tsv)
 
     echo "SATELLITE_VM_PRIVATE_IP: ${SATELLITE_VM_PRIVATE_IP}"

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
@@ -248,6 +248,9 @@ if [ "${CONNECT_SATELLITE}" == "true" ]; then
 
     echo "sudo subscription-manager register --org=/"${SATELLITE_ORG_NAME}/" --activationkey=/"${SATELLITE_ACTIVATION_KEY}/"" | log; flag=${PIPESTATUS[0]}
     sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}
+
+    echo "sudo sed -i "${SATELLITE_VM_PRIVATE_IP}  ${SATELLITE_VM_FQDN}" /etc/hosts"
+    sudo sed -i "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" /etc/hosts
 fi
 
 # Seeing a race condition timing error so sleep to delay

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
@@ -244,17 +244,21 @@ $EAP_HOME/wildfly/bin/add-user.sh  -u $JBOSS_EAP_USER -p $JBOSS_EAP_PASSWORD -g 
 if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP management user configuration Failed" >&2 log; exit $flag;  fi
 
 # Satellite server configuration
+echo "CONNECT_SATELLITE: ${CONNECT_SATELLITE}"
 if [[ "${CONNECT_SATELLITE,,}" == "true" ]]; then
     echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
 
-    echo "sudo sed -i "${SATELLITE_VM_PRIVATE_IP}  ${SATELLITE_VM_FQDN}" /etc/hosts" | log; flag=${PIPESTATUS[0]}
-    sudo sed -i "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" /etc/hosts | log; flag=${PIPESTATUS[0]}
+    echo "echo "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" | sudo tee -a /etc/hosts" | log; flag=${PIPESTATUS[0]}
+    echo "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" | sudo tee -a /etc/hosts | log; flag=${PIPESTATUS[0]}
 
     echo "sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm" | log; flag=${PIPESTATUS[0]}
     sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm | log; flag=${PIPESTATUS[0]}
 
-    echo "sudo subscription-manager register --org=/"${SATELLITE_ORG_NAME}/" --activationkey=/"${SATELLITE_ACTIVATION_KEY}/"" | log; flag=${PIPESTATUS[0]}
-    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY} | log; flag=${PIPESTATUS[0]}
+    echo "sudo subscription-manager clean" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager clean | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY} --force | log; flag=${PIPESTATUS[0]}
 fi
 
 # Seeing a race condition timing error so sleep to delay

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
@@ -244,7 +244,7 @@ $EAP_HOME/wildfly/bin/add-user.sh  -u $JBOSS_EAP_USER -p $JBOSS_EAP_PASSWORD -g 
 if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP management user configuration Failed" >&2 log; exit $flag;  fi
 
 # Satellite server configuration
-if [ "${CONNECT_SATELLITE}" == "true" ]; then
+if [[ "${CONNECT_SATELLITE,,}" == "true" ]]; then
     echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
 
     echo "sudo sed -i "${SATELLITE_VM_PRIVATE_IP}  ${SATELLITE_VM_FQDN}" /etc/hosts" | log; flag=${PIPESTATUS[0]}

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
@@ -106,9 +106,6 @@ HOST_VM_NAME=$(hostname)
 HOST_VM_NAME_LOWERCASES=$(echo "${HOST_VM_NAME,,}")
 HOST_VM_IP=$(hostname -I)
 
-echo "all prameters: "
-echo $@
-
 MOUNT_POINT_PATH=/mnt/jbossshare
 SCRIPT_PWD=`pwd`
 

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
@@ -97,10 +97,11 @@ STORAGE_ACCOUNT_PRIVATE_IP=${17}
 DOMAIN_CONTROLLER_PRIVATE_IP=${18}
 NUMBER_OF_SERVER_INSTANCE=${19}
 CONNECT_SATELLITE=${20}
-SATELLITE_ACTIVATION_KEY=${21}
-SATELLITE_ORG_NAME=${22}
+SATELLITE_ACTIVATION_KEY_BASE64=${21}
+SATELLITE_ACTIVATION_KEY=$(echo $SATELLITE_ACTIVATION_KEY_BASE64 | base64 -d)
+SATELLITE_ORG_NAME_BASE64=${22}
+SATELLITE_ORG_NAME=$(echo $SATELLITE_ORG_NAME_BASE64 | base64 -d)
 SATELLITE_VM_FQDN=${23}
-SATELLITE_VM_PRIVATE_IP=${24}
 HOST_VM_NAME=$(hostname)
 HOST_VM_NAME_LOWERCASES=$(echo "${HOST_VM_NAME,,}")
 HOST_VM_IP=$(hostname -I)
@@ -134,21 +135,38 @@ sudo iptables-save   | log; flag=${PIPESTATUS[0]}
 ####################### 
 
 echo "Initial JBoss EAP setup" | log; flag=${PIPESTATUS[0]}
-####################### Register to subscription Manager
-echo "Register subscription manager" | log; flag=${PIPESTATUS[0]}
-echo "subscription-manager register --username RHSM_USER --password RHSM_PASSWORD" | log; flag=${PIPESTATUS[0]}
-subscription-manager register --username $RHSM_USER --password $RHSM_PASSWORD --force | log; flag=${PIPESTATUS[0]}
-if [ $flag != 0 ] ; then echo  "ERROR! Red Hat Manager Registration Failed" >&2 log; exit $flag;  fi
-#######################
 
-sleep 20
+# Satellite server configuration
+echo "CONNECT_SATELLITE: ${CONNECT_SATELLITE}"
+if [[ "${CONNECT_SATELLITE,,}" == "true" ]]; then
+    ####################### Register to satellite server
+    echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
 
-####################### Attach EAP Pool
-echo "Subscribing the system to get access to JBoss EAP repos" | log; flag=${PIPESTATUS[0]}
-echo "subscription-manager attach --pool=EAP_POOL" | log; flag=${PIPESTATUS[0]}
-subscription-manager attach --pool=${EAP_POOL} | log; flag=${PIPESTATUS[0]}
-if [ $flag != 0 ] ; then echo  "ERROR! Pool Attach for JBoss EAP Failed" >&2 log; exit $flag;  fi
-#######################
+    echo "sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm" | log; flag=${PIPESTATUS[0]}
+    sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo subscription-manager clean" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager clean | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager register --org="${SATELLITE_ORG_NAME}" --activationkey="${SATELLITE_ACTIVATION_KEY}" --force | log; flag=${PIPESTATUS[0]}
+else
+    ####################### Register to subscription Manager
+    echo "Register subscription manager" | log; flag=${PIPESTATUS[0]}
+    echo "subscription-manager register --username RHSM_USER --password RHSM_PASSWORD" | log; flag=${PIPESTATUS[0]}
+    subscription-manager register --username $RHSM_USER --password $RHSM_PASSWORD --force | log; flag=${PIPESTATUS[0]}
+    if [ $flag != 0 ] ; then echo  "ERROR! Red Hat Manager Registration Failed" >&2 log; exit $flag;  fi
+    #######################
+
+    sleep 20
+
+    ####################### Attach EAP Pool
+    echo "Subscribing the system to get access to JBoss EAP repos" | log; flag=${PIPESTATUS[0]}
+    echo "subscription-manager attach --pool=EAP_POOL" | log; flag=${PIPESTATUS[0]}
+    subscription-manager attach --pool=${EAP_POOL} | log; flag=${PIPESTATUS[0]}
+    if [ $flag != 0 ] ; then echo  "ERROR! Pool Attach for JBoss EAP Failed" >&2 log; exit $flag;  fi
+    #######################
+fi
 
 ####################### Install openjdk: is it needed? it should be installed with eap7.4
 echo "Install openjdk, curl, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
@@ -242,24 +260,6 @@ echo "Configuring JBoss EAP management user..." | log; flag=${PIPESTATUS[0]}
 echo "$EAP_HOME/wildfly/bin/add-user.sh -u JBOSS_EAP_USER -p JBOSS_EAP_PASSWORD -g 'guest,mgmtgroup'" | log; flag=${PIPESTATUS[0]}
 $EAP_HOME/wildfly/bin/add-user.sh  -u $JBOSS_EAP_USER -p $JBOSS_EAP_PASSWORD -g 'guest,mgmtgroup' | log; flag=${PIPESTATUS[0]}
 if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP management user configuration Failed" >&2 log; exit $flag;  fi
-
-# Satellite server configuration
-echo "CONNECT_SATELLITE: ${CONNECT_SATELLITE}"
-if [[ "${CONNECT_SATELLITE,,}" == "true" ]]; then
-    echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
-
-    echo "echo "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" | sudo tee -a /etc/hosts" | log; flag=${PIPESTATUS[0]}
-    echo "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" | sudo tee -a /etc/hosts | log; flag=${PIPESTATUS[0]}
-
-    echo "sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm" | log; flag=${PIPESTATUS[0]}
-    sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm | log; flag=${PIPESTATUS[0]}
-
-    echo "sudo subscription-manager clean" | log; flag=${PIPESTATUS[0]}
-    sudo subscription-manager clean | log; flag=${PIPESTATUS[0]}
-
-    echo "sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}" | log; flag=${PIPESTATUS[0]}
-    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY} --force | log; flag=${PIPESTATUS[0]}
-fi
 
 # Seeing a race condition timing error so sleep to delay
 sleep 20

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
@@ -96,6 +96,11 @@ STORAGE_ACCESS_KEY=${16}
 STORAGE_ACCOUNT_PRIVATE_IP=${17}
 DOMAIN_CONTROLLER_PRIVATE_IP=${18}
 NUMBER_OF_SERVER_INSTANCE=${19}
+CONNECT_SATELLITE=${20}
+SATELLITE_ACTIVATION_KEY=${21}
+SATELLITE_ORG_NAME=${22}
+SATELLITE_VM_FQDN=${23}
+SATELLITE_VM_PRIVATE_IP=${24}
 HOST_VM_NAME=$(hostname)
 HOST_VM_NAME_LOWERCASES=$(echo "${HOST_VM_NAME,,}")
 HOST_VM_IP=$(hostname -I)
@@ -234,6 +239,16 @@ echo "Configuring JBoss EAP management user..." | log; flag=${PIPESTATUS[0]}
 echo "$EAP_HOME/wildfly/bin/add-user.sh -u JBOSS_EAP_USER -p JBOSS_EAP_PASSWORD -g 'guest,mgmtgroup'" | log; flag=${PIPESTATUS[0]}
 $EAP_HOME/wildfly/bin/add-user.sh  -u $JBOSS_EAP_USER -p $JBOSS_EAP_PASSWORD -g 'guest,mgmtgroup' | log; flag=${PIPESTATUS[0]}
 if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP management user configuration Failed" >&2 log; exit $flag;  fi
+
+# Satellite server configuration
+if [ "${CONNECT_SATELLITE}" == "true" ]; then
+    echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
+    echo "sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm" | log; flag=${PIPESTATUS[0]}
+    sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm
+
+    echo "sudo subscription-manager register --org=/"${SATELLITE_ORG_NAME}/" --activationkey=/"${SATELLITE_ACTIVATION_KEY}/"" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}
+fi
 
 # Seeing a race condition timing error so sleep to delay
 sleep 20

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
@@ -105,6 +105,9 @@ HOST_VM_NAME=$(hostname)
 HOST_VM_NAME_LOWERCASES=$(echo "${HOST_VM_NAME,,}")
 HOST_VM_IP=$(hostname -I)
 
+echo "all prameters: "
+echo $@
+
 MOUNT_POINT_PATH=/mnt/jbossshare
 SCRIPT_PWD=`pwd`
 
@@ -243,14 +246,15 @@ if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP management user configuration F
 # Satellite server configuration
 if [ "${CONNECT_SATELLITE}" == "true" ]; then
     echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo sed -i "${SATELLITE_VM_PRIVATE_IP}  ${SATELLITE_VM_FQDN}" /etc/hosts" | log; flag=${PIPESTATUS[0]}
+    sudo sed -i "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" /etc/hosts | log; flag=${PIPESTATUS[0]}
+
     echo "sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm" | log; flag=${PIPESTATUS[0]}
-    sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm
+    sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm | log; flag=${PIPESTATUS[0]}
 
     echo "sudo subscription-manager register --org=/"${SATELLITE_ORG_NAME}/" --activationkey=/"${SATELLITE_ACTIVATION_KEY}/"" | log; flag=${PIPESTATUS[0]}
-    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}
-
-    echo "sudo sed -i "${SATELLITE_VM_PRIVATE_IP}  ${SATELLITE_VM_FQDN}" /etc/hosts"
-    sudo sed -i "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" /etc/hosts
+    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY} | log; flag=${PIPESTATUS[0]}
 fi
 
 # Seeing a race condition timing error so sleep to delay

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-standalone.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-standalone.sh
@@ -201,6 +201,9 @@ if [ "${CONNECT_SATELLITE}" == "true" ]; then
 
     echo "sudo subscription-manager register --org=/"${SATELLITE_ORG_NAME}/" --activationkey=/"${SATELLITE_ACTIVATION_KEY}/"" | log; flag=${PIPESTATUS[0]}
     sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}
+
+    echo "sudo sed -i "${SATELLITE_VM_PRIVATE_IP}  ${SATELLITE_VM_FQDN}" /etc/hosts"
+    sudo sed -i "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" /etc/hosts
 fi
 
 # Seeing a race condition timing error so sleep to delay

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-standalone.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-standalone.sh
@@ -52,13 +52,17 @@ STORAGE_ACCOUNT_NAME=${14}
 CONTAINER_NAME=${15}
 STORAGE_ACCESS_KEY=${16}
 CONNECT_SATELLITE=${17}
-SATELLITE_ACTIVATION_KEY=${18}
-SATELLITE_ORG_NAME=${19}
+SATELLITE_ACTIVATION_KEY_BASE64=${18}
+SATELLITE_ACTIVATION_KEY=$(echo $SATELLITE_ACTIVATION_KEY_BASE64 | base64 -d)
+SATELLITE_ORG_NAME_BASE64=${22}
+SATELLITE_ORG_NAME_BASE64=${19}
 SATELLITE_VM_FQDN=${20}
-SATELLITE_VM_PRIVATE_IP=${21}
 NODE_ID=$(uuidgen | sed 's/-//g' | cut -c 1-23)
 HOST_VM_NAME=$(hostname)
 HOST_VM_NAME_LOWERCASES=$(echo "${HOST_VM_NAME,,}")
+
+echo "all prameters: "
+echo $@
 
 echo "JBoss EAP admin user: " ${JBOSS_EAP_USER} | log; flag=${PIPESTATUS[0]}
 echo "JBoss EAP on RHEL version you selected : JBoss-EAP7.4-on-RHEL8.4" | log; flag=${PIPESTATUS[0]}
@@ -87,21 +91,37 @@ sudo iptables-save   | log; flag=${PIPESTATUS[0]}
 ####################### 
 
 echo "Initial JBoss EAP setup" | log; flag=${PIPESTATUS[0]}
-####################### Register to subscription Manager
-echo "Register subscription manager" | log; flag=${PIPESTATUS[0]}
-echo "subscription-manager register --username RHSM_USER --password RHSM_PASSWORD" | log; flag=${PIPESTATUS[0]}
-subscription-manager register --username $RHSM_USER --password $RHSM_PASSWORD --force | log; flag=${PIPESTATUS[0]}
-if [ $flag != 0 ] ; then echo  "ERROR! Red Hat Manager Registration Failed" >&2 log; exit $flag;  fi
-#######################
 
-sleep 20
+# Satellite server configuration
+if [[ "${CONNECT_SATELLITE,,}" == "true" ]]; then
+    ####################### Register to satellite server
+    echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
 
-####################### Attach EAP Pool
-echo "Subscribing the system to get access to JBoss EAP repos" | log; flag=${PIPESTATUS[0]}
-echo "subscription-manager attach --pool=EAP_POOL" | log; flag=${PIPESTATUS[0]}
-subscription-manager attach --pool=${EAP_POOL} | log; flag=${PIPESTATUS[0]}
-if [ $flag != 0 ] ; then echo  "ERROR! Pool Attach for JBoss EAP Failed" >&2 log; exit $flag;  fi
-#######################
+    echo "sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm" | log; flag=${PIPESTATUS[0]}
+    sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo subscription-manager clean" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager clean | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager register --org="${SATELLITE_ORG_NAME}" --activationkey="${SATELLITE_ACTIVATION_KEY}" --force | log; flag=${PIPESTATUS[0]}
+else
+    ####################### Register to subscription Manager
+    echo "Register subscription manager" | log; flag=${PIPESTATUS[0]}
+    echo "subscription-manager register --username RHSM_USER --password RHSM_PASSWORD" | log; flag=${PIPESTATUS[0]}
+    subscription-manager register --username $RHSM_USER --password $RHSM_PASSWORD --force | log; flag=${PIPESTATUS[0]}
+    if [ $flag != 0 ] ; then echo  "ERROR! Red Hat Manager Registration Failed" >&2 log; exit $flag;  fi
+    #######################
+
+    sleep 20
+
+    ####################### Attach EAP Pool
+    echo "Subscribing the system to get access to JBoss EAP repos" | log; flag=${PIPESTATUS[0]}
+    echo "subscription-manager attach --pool=EAP_POOL" | log; flag=${PIPESTATUS[0]}
+    subscription-manager attach --pool=${EAP_POOL} | log; flag=${PIPESTATUS[0]}
+    if [ $flag != 0 ] ; then echo  "ERROR! Pool Attach for JBoss EAP Failed" >&2 log; exit $flag;  fi
+    #######################
+fi
 
 ####################### Install openjdk: is it needed? it should be installed with eap7.4
 echo "Install openjdk, curl, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
@@ -192,23 +212,6 @@ echo "Configuring JBoss EAP management user..." | log; flag=${PIPESTATUS[0]}
 echo "$EAP_HOME/wildfly/bin/add-user.sh -u JBOSS_EAP_USER -p JBOSS_EAP_PASSWORD -g 'guest,mgmtgroup'" | log; flag=${PIPESTATUS[0]}
 $EAP_HOME/wildfly/bin/add-user.sh  -u $JBOSS_EAP_USER -p $JBOSS_EAP_PASSWORD -g 'guest,mgmtgroup' | log; flag=${PIPESTATUS[0]}
 if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP management user configuration Failed" >&2 log; exit $flag;  fi
-
-# Satellite server configuration
-if [[ "${CONNECT_SATELLITE,,}" == "true" ]]; then
-    echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
-
-    echo "echo "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" | sudo tee -a /etc/hosts" | log; flag=${PIPESTATUS[0]}
-    echo "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" | sudo tee -a /etc/hosts | log; flag=${PIPESTATUS[0]}
-
-    echo "sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm" | log; flag=${PIPESTATUS[0]}
-    sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm | log; flag=${PIPESTATUS[0]}
-
-    echo "sudo subscription-manager clean" | log; flag=${PIPESTATUS[0]}
-    sudo subscription-manager clean | log; flag=${PIPESTATUS[0]}
-
-    echo "sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}" | log; flag=${PIPESTATUS[0]}
-    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY} --force | log; flag=${PIPESTATUS[0]}
-fi
 
 # Seeing a race condition timing error so sleep to delay
 sleep 20

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-standalone.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-standalone.sh
@@ -61,9 +61,6 @@ NODE_ID=$(uuidgen | sed 's/-//g' | cut -c 1-23)
 HOST_VM_NAME=$(hostname)
 HOST_VM_NAME_LOWERCASES=$(echo "${HOST_VM_NAME,,}")
 
-echo "all prameters: "
-echo $@
-
 echo "JBoss EAP admin user: " ${JBOSS_EAP_USER} | log; flag=${PIPESTATUS[0]}
 echo "JBoss EAP on RHEL version you selected : JBoss-EAP7.4-on-RHEL8.4" | log; flag=${PIPESTATUS[0]}
 echo "Storage Account Name: " ${STORAGE_ACCOUNT_NAME} | log; flag=${PIPESTATUS[0]}

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-standalone.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-standalone.sh
@@ -197,14 +197,17 @@ if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP management user configuration F
 if [[ "${CONNECT_SATELLITE,,}" == "true" ]]; then
     echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
 
-    echo "sudo sed -i "${SATELLITE_VM_PRIVATE_IP}  ${SATELLITE_VM_FQDN}" /etc/hosts" | log; flag=${PIPESTATUS[0]}
-    sudo sed -i "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" /etc/hosts | log; flag=${PIPESTATUS[0]}
+    echo "echo "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" | sudo tee -a /etc/hosts" | log; flag=${PIPESTATUS[0]}
+    echo "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" | sudo tee -a /etc/hosts | log; flag=${PIPESTATUS[0]}
 
     echo "sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm" | log; flag=${PIPESTATUS[0]}
     sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm | log; flag=${PIPESTATUS[0]}
 
-    echo "sudo subscription-manager register --org=/"${SATELLITE_ORG_NAME}/" --activationkey=/"${SATELLITE_ACTIVATION_KEY}/"" | log; flag=${PIPESTATUS[0]}
-    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY} | log; flag=${PIPESTATUS[0]}
+    echo "sudo subscription-manager clean" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager clean | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY} --force | log; flag=${PIPESTATUS[0]}
 fi
 
 # Seeing a race condition timing error so sleep to delay

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-standalone.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-standalone.sh
@@ -194,7 +194,7 @@ $EAP_HOME/wildfly/bin/add-user.sh  -u $JBOSS_EAP_USER -p $JBOSS_EAP_PASSWORD -g 
 if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP management user configuration Failed" >&2 log; exit $flag;  fi
 
 # Satellite server configuration
-if [ "${CONNECT_SATELLITE}" == "true" ]; then
+if [[ "${CONNECT_SATELLITE,,}" == "true" ]]; then
     echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
 
     echo "sudo sed -i "${SATELLITE_VM_PRIVATE_IP}  ${SATELLITE_VM_FQDN}" /etc/hosts" | log; flag=${PIPESTATUS[0]}

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-standalone.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-standalone.sh
@@ -51,6 +51,11 @@ EAP_POOL=${13}
 STORAGE_ACCOUNT_NAME=${14}
 CONTAINER_NAME=${15}
 STORAGE_ACCESS_KEY=${16}
+CONNECT_SATELLITE=${17}
+SATELLITE_ACTIVATION_KEY=${18}
+SATELLITE_ORG_NAME=${19}
+SATELLITE_VM_FQDN=${20}
+SATELLITE_VM_PRIVATE_IP=${21}
 NODE_ID=$(uuidgen | sed 's/-//g' | cut -c 1-23)
 HOST_VM_NAME=$(hostname)
 HOST_VM_NAME_LOWERCASES=$(echo "${HOST_VM_NAME,,}")
@@ -187,6 +192,16 @@ echo "Configuring JBoss EAP management user..." | log; flag=${PIPESTATUS[0]}
 echo "$EAP_HOME/wildfly/bin/add-user.sh -u JBOSS_EAP_USER -p JBOSS_EAP_PASSWORD -g 'guest,mgmtgroup'" | log; flag=${PIPESTATUS[0]}
 $EAP_HOME/wildfly/bin/add-user.sh  -u $JBOSS_EAP_USER -p $JBOSS_EAP_PASSWORD -g 'guest,mgmtgroup' | log; flag=${PIPESTATUS[0]}
 if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP management user configuration Failed" >&2 log; exit $flag;  fi
+
+# Satellite server configuration
+if [ "${CONNECT_SATELLITE}" == "true" ]; then
+    echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
+    echo "sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm" | log; flag=${PIPESTATUS[0]}
+    sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm
+
+    echo "sudo subscription-manager register --org=/"${SATELLITE_ORG_NAME}/" --activationkey=/"${SATELLITE_ACTIVATION_KEY}/"" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}
+fi
 
 # Seeing a race condition timing error so sleep to delay
 sleep 20

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-standalone.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-standalone.sh
@@ -196,14 +196,15 @@ if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP management user configuration F
 # Satellite server configuration
 if [ "${CONNECT_SATELLITE}" == "true" ]; then
     echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo sed -i "${SATELLITE_VM_PRIVATE_IP}  ${SATELLITE_VM_FQDN}" /etc/hosts" | log; flag=${PIPESTATUS[0]}
+    sudo sed -i "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" /etc/hosts | log; flag=${PIPESTATUS[0]}
+
     echo "sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm" | log; flag=${PIPESTATUS[0]}
-    sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm
+    sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm | log; flag=${PIPESTATUS[0]}
 
     echo "sudo subscription-manager register --org=/"${SATELLITE_ORG_NAME}/" --activationkey=/"${SATELLITE_ACTIVATION_KEY}/"" | log; flag=${PIPESTATUS[0]}
-    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}
-
-    echo "sudo sed -i "${SATELLITE_VM_PRIVATE_IP}  ${SATELLITE_VM_FQDN}" /etc/hosts"
-    sudo sed -i "${SATELLITE_VM_PRIVATE_IP} ${SATELLITE_VM_FQDN}" /etc/hosts
+    sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY} | log; flag=${PIPESTATUS[0]}
 fi
 
 # Seeing a race condition timing error so sleep to delay


### PR DESCRIPTION
## Main Changes
* Add new tab to UI, allow users to provide Satellite server's FQDN (need to pre-configured by the users themselves to ensure the networking is viable), Organization Name and Activation Key
* If users enabled the Satellite server feature, register the RHEL hosts to the Satellite, then install JBoss EAP 7.4 (related repos need to be enabled by user themselves through Satellite) and setup the cluster (Both standalone mode and domain mode)
* Support passwords with special characters

## Test (Both ARM template and preview offer)
   * Single mode with existing VNET, register to Satellite
   * Single mode with existing VNET, not register to Satellite
   * Domain mode with new VNET, register to Satellite
   * Domain mode with existing VNET, not register to Satellite
   * [Pipeline validation](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/2646846747)
