### PR TITLE
Support 'Register hosts to existing Satellite server' for eap74-rhel8-payg-vmss

### DIFF
--- a/eap74-rhel8-payg-vmss/pom.xml
+++ b/eap74-rhel8-payg-vmss/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-payg-vmss</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/eap74-rhel8-payg-vmss/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-vmss/src/main/arm/createUiDefinition.json
@@ -278,6 +278,85 @@
                 ]
             },
             {
+                "name": "satelliteServerSettings",
+                "label": "Satellite Server Settings",
+                "subLabel": {
+                    "preValidation": "Provide the settings for Satellite Server registration",
+                    "postValidation": "Done"
+                },
+                "bladeTitle": "Satellite Server Settings",
+                "elements": [
+                    {
+                        "name": "connectToSatelliteServer",
+                        "type": "Microsoft.Common.TextBlock",
+                        "visible": true,
+                        "options": {
+                            "text": "Selecting 'Yes' here will cause the template to register JBoss EAP hosts to an existing Red Hat Satellite Server. Further configuration may be necessary after deployment.",
+                            "link": {
+                                "label": "Learn more",
+                                "uri": "https://access.redhat.com/products/red-hat-satellite"
+                            }
+                        }
+                    },
+                    {
+                        "name": "connectSatellite",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Connect to an existing Red Hat Satellite Server?",
+                        "defaultValue": "No",
+                        "toolTip": "Select 'Yes' to register JBoss EAP hosts created in preview step to an existing Red Hat.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": true
+                                },
+                                {
+                                    "label": "No",
+                                    "value": false
+                                }
+                            ],
+                            "required": false
+                        }
+                    },
+                    {
+                        "name": "satelliteActivationKey",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+                        "label": "The template will need the activation key to register the JBoss EAP host to the Red Hat Satellite server.",
+                        "toolTip": "Activation key",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^.{1,}$",
+                            "validationMessage": "Cannot be empty."
+                        }
+                    },
+                    {
+                        "name": "satelliteOrgName",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+                        "label": "The template will need the Organization name to register the JBoss EAP host to the Red Hat Satellite server.",
+                        "toolTip": "Organization name",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^.{1,}$",
+                            "validationMessage": "Cannot be empty."
+                        }
+                    },
+                    {
+                        "name": "satelliteFqdn",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+                        "label": "The template will need the Fully Qualified Domain Name of Satellite Server virtual machine.",
+                        "toolTip": "Fully Qualified Domain Name of Satellite Sever VM",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^.{1,}$",
+                            "validationMessage": "Cannot be empty."
+                        }
+                    }
+				]
+            },
+            {
                 "name": "jbossEAPSettings",
                 "label": "JBoss EAP Settings",
                 "subLabel": {
@@ -315,6 +394,7 @@
                     {
                         "name": "rhsmUserName",
                         "type": "Microsoft.Common.TextBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
                         "label": "RHSM username",
                         "constraints": {
                             "required": true,
@@ -326,6 +406,7 @@
                     {
                         "name": "rhsmPassword",
                         "type": "Microsoft.Common.PasswordBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
                         "label": {
                             "password": "RHSM password",
                             "confirmPassword": "Confirm password"
@@ -342,6 +423,7 @@
                     {
                         "name": "rhsmPoolEAP",
                         "type": "Microsoft.Common.TextBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
                         "label": "RHSM Pool ID with EAP entitlement",
                         "toolTip": "Red Hat Subscription Manager Pool ID (Should have EAP entitlement)",
                         "constraints": {
@@ -382,7 +464,11 @@
             "jbossEAPPassword": "[steps('jbossEAPSettings').jbossEAPPassword]",
             "rhsmUserName": "[steps('jbossEAPSettings').rhsmUserName]",
             "rhsmPassword": "[steps('jbossEAPSettings').rhsmPassword]",
-            "rhsmPoolEAP": "[steps('jbossEAPSettings').rhsmPoolEAP]"
+            "rhsmPoolEAP": "[steps('jbossEAPSettings').rhsmPoolEAP]",
+            "connectSatellite": "[steps('satelliteServerSettings').connectSatellite]",
+            "satelliteActivationKey": "[steps('satelliteServerSettings').satelliteActivationKey]",
+            "satelliteOrgName": "[steps('satelliteServerSettings').satelliteOrgName]",
+            "satelliteFqdn": "[steps('satelliteServerSettings').satelliteFqdn]"
         }
     }
 }

--- a/eap74-rhel8-payg-vmss/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-vmss/src/main/arm/createUiDefinition.json
@@ -411,7 +411,6 @@
                             "password": "RHSM password",
                             "confirmPassword": "Confirm password"
                         },
-                        "visible": true,
                         "toolTip": "Provide Password for  Red Hat subscription Manager",
                         "options": {
                             "hideConfirmation": false

--- a/eap74-rhel8-payg-vmss/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-payg-vmss/src/main/bicep/mainTemplate.bicep
@@ -25,14 +25,14 @@ param jbossEAPUserName string
 param jbossEAPPassword string
 
 @description('User name for Red Hat subscription Manager')
-param rhsmUserName string
+param rhsmUserName string = newGuid()
 
 @description('Password for Red Hat subscription Manager')
 @secure()
-param rhsmPassword string
+param rhsmPassword string = newGuid()
 
 @description('Red Hat Subscription Manager Pool ID (Should have EAP entitlement)')
-param rhsmPoolEAP string
+param rhsmPoolEAP string = newGuid()
 
 @allowed([
   'on'

--- a/eap74-rhel8-payg-vmss/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-payg-vmss/src/main/bicep/mainTemplate.bicep
@@ -110,6 +110,18 @@ param artifactsLocation string = deployment().properties.templateLink.uri
 @secure()
 param artifactsLocationSasToken string = ''
 
+@description('Connect to an existing Red Hat Satellite Server.')
+param connectSatellite bool = false
+
+@description('Red Hat Satellite Server activation key.')
+param satelliteActivationKey string = ''
+
+@description('Red Hat Satellite Server organization name.')
+param satelliteOrgName string = ''
+
+@description('Red Hat Satellite Server VM FQDN name.')
+param satelliteFqdn string = ''
+
 var containerName = 'eapblobcontainer'
 var eapStorageAccountName_var = 'jbosstrg${uniqueString(resourceGroup().id)}'
 var eapstorageReplication = 'Standard_LRS'
@@ -282,7 +294,7 @@ resource vmssInstanceName 'Microsoft.Compute/virtualMachineScaleSets@2021-03-01'
                 ]
               }
               protectedSettings: {
-                commandToExecute: 'sh jbosseap-setup-redhat.sh ${scriptArgs} \'${jbossEAPUserName}\' \'${base64(jbossEAPPassword)}\' \'${rhsmUserName}\' \'${base64(rhsmPassword)}\' \'${rhsmPoolEAP}\' \'${eapStorageAccountName_var}\' \'${containerName}\' \'${base64(listKeys(eapStorageAccountName.id, '2021-06-01').keys[0].value)}\''
+                commandToExecute: 'sh jbosseap-setup-redhat.sh ${scriptArgs} \'${jbossEAPUserName}\' \'${base64(jbossEAPPassword)}\' \'${rhsmUserName}\' \'${base64(rhsmPassword)}\' \'${rhsmPoolEAP}\' \'${eapStorageAccountName_var}\' \'${containerName}\' \'${base64(listKeys(eapStorageAccountName.id, '2021-06-01').keys[0].value)}\' \'${connectSatellite}\' \'${base64(satelliteActivationKey)}\' \'${base64(satelliteOrgName)}\' \'${satelliteFqdn}\''
               }
             }
           }

--- a/eap74-rhel8-payg-vmss/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-payg-vmss/src/main/scripts/jbosseap-setup-redhat.sh
@@ -51,6 +51,12 @@ RHSM_POOL=${13}
 STORAGE_ACCOUNT_NAME=${14}
 CONTAINER_NAME=${15}
 STORAGE_ACCESS_KEY=$(echo "${16}" | openssl enc -d -base64)
+CONNECT_SATELLITE=${17}
+SATELLITE_ACTIVATION_KEY_BASE64=${18}
+SATELLITE_ACTIVATION_KEY=$(echo $SATELLITE_ACTIVATION_KEY_BASE64 | base64 -d)
+SATELLITE_ORG_NAME_BASE64=${19}
+SATELLITE_ORG_NAME=$(echo $SATELLITE_ORG_NAME_BASE64 | base64 -d)
+SATELLITE_VM_FQDN=${20}
 NODE_ID=$(uuidgen | sed 's/-//g' | cut -c 1-23)
 
 echo "JBoss EAP admin user: " ${JBOSS_EAP_USER} | log; flag=${PIPESTATUS[0]}
@@ -75,19 +81,35 @@ echo "iptables-save" | log; flag=${PIPESTATUS[0]}
 sudo iptables-save | log; flag=${PIPESTATUS[0]}
 ####################### 
 
-echo "Initial JBoss EAP setup" | log; flag=${PIPESTATUS[0]}
-####################### Register to subscription Manager
-echo "Register subscription manager" | log; flag=${PIPESTATUS[0]}
-echo "subscription-manager register --username RHSM_USER --password RHSM_PASSWORD" | log; flag=${PIPESTATUS[0]}
-subscription-manager register --username $RHSM_USER --password $RHSM_PASSWORD --force | log; flag=${PIPESTATUS[0]}
-if [ $flag != 0 ] ; then echo  "ERROR! Red Hat Manager Registration Failed" >&2 log; exit $flag;  fi
-#######################
-####################### Attach EAP Pool
-echo "Subscribing the system to get access to JBoss EAP repos" | log; flag=${PIPESTATUS[0]}
-echo "subscription-manager attach --pool=EAP_POOL" | log; flag=${PIPESTATUS[0]}
-subscription-manager attach --pool=${RHSM_POOL} | log; flag=${PIPESTATUS[0]}
-if [ $flag != 0 ] ; then echo  "ERROR! Pool Attach for JBoss EAP Failed" >&2 log; exit $flag;  fi
-#######################
+# Satellite server configuration
+echo "CONNECT_SATELLITE: ${CONNECT_SATELLITE}"
+if [[ "${CONNECT_SATELLITE,,}" == "true" ]]; then
+    ####################### Register to satellite server
+    echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm" | log; flag=${PIPESTATUS[0]}
+    sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo subscription-manager clean" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager clean | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager register --org="${SATELLITE_ORG_NAME}" --activationkey="${SATELLITE_ACTIVATION_KEY}" --force | log; flag=${PIPESTATUS[0]}
+else
+    echo "Initial JBoss EAP setup" | log; flag=${PIPESTATUS[0]}
+    ####################### Register to subscription Manager
+    echo "Register subscription manager" | log; flag=${PIPESTATUS[0]}
+    echo "subscription-manager register --username RHSM_USER --password RHSM_PASSWORD" | log; flag=${PIPESTATUS[0]}
+    subscription-manager register --username $RHSM_USER --password $RHSM_PASSWORD --force | log; flag=${PIPESTATUS[0]}
+    if [ $flag != 0 ] ; then echo  "ERROR! Red Hat Manager Registration Failed" >&2 log; exit $flag;  fi
+    #######################
+    ####################### Attach EAP Pool
+    echo "Subscribing the system to get access to JBoss EAP repos" | log; flag=${PIPESTATUS[0]}
+    echo "subscription-manager attach --pool=EAP_POOL" | log; flag=${PIPESTATUS[0]}
+    subscription-manager attach --pool=${RHSM_POOL} | log; flag=${PIPESTATUS[0]}
+    if [ $flag != 0 ] ; then echo  "ERROR! Pool Attach for JBoss EAP Failed" >&2 log; exit $flag;  fi
+    #######################
+fi
 
 ####################### Install openjdk: is it needed? it should be installed with eap7.4
 echo "Install openjdk, curl, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}


### PR DESCRIPTION
## Main Changes
* Add new tab to UI, allow users to provide Satellite server's FQDN (need to pre-configured by the users themselves to ensure the networking is viable), Organization Name and Activation Key
* If users enabled the Satellite server feature, register the RHEL hosts to the Satellite, then install JBoss EAP 7.4 (related repos need to be enabled by user themselves through Satellite) and setup the cluster (Both standalone mode and domain mode)

## Test
   * Register to Satellite (Both ARM template and preview offer)
   * Not register to Satellite (Both ARM template and preview offer)
   * [Pipeline validation](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/2745153783)
