### PR TITLE
Bugfix for 'fast fail' script

### DIFF
--- a/eap74-rhel8-payg-multivm/pom.xml
+++ b/eap74-rhel8-payg-multivm/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-payg-multivm</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     

--- a/eap74-rhel8-payg-multivm/src/main/scripts/validate-parameters.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/validate-parameters.sh
@@ -141,7 +141,8 @@ location=$1
 vmSize=$2
 numberOfInstances=$3
 connectSatellite=$4
-satelliteFqdn=$5
+DEFAULT_SATELLITE_FQDN="invalid-fqdn"
+satelliteFqdn="${5:-$DEFAULT_SATELLITE_FQDN}"
 userManagedIdentityType="Microsoft.ManagedIdentity/userAssignedIdentities"
 
 validate_user_assigned_managed_identity


### PR DESCRIPTION
## Change
Add default value for `satelliteFqdn` in `eap74-rhel8-payg-multivm/src/main/scripts/validate-parameters.sh` to pass the `set -e` check

## Test
* [Pipeline](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/2771652925)
* Deploy with Satellite feature using [preview offer](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20220323-zheng-test-offer-previewjboss-eap-cluster-vm)