### PR TITLE
Support 'Register hosts to existing Satellite server' for eap74-rhel8-byos-vmss

### DIFF
--- a/eap74-rhel8-byos-vmss/pom.xml
+++ b/eap74-rhel8-byos-vmss/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-byos-vmss</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/eap74-rhel8-byos-vmss/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-byos-vmss/src/main/arm/createUiDefinition.json
@@ -278,6 +278,85 @@
                 ]
             },
             {
+                "name": "satelliteServerSettings",
+                "label": "Satellite Server Settings",
+                "subLabel": {
+                    "preValidation": "Provide the settings for Satellite Server registration",
+                    "postValidation": "Done"
+                },
+                "bladeTitle": "Satellite Server Settings",
+                "elements": [
+                    {
+                        "name": "connectToSatelliteServer",
+                        "type": "Microsoft.Common.TextBlock",
+                        "visible": true,
+                        "options": {
+                            "text": "Selecting 'Yes' here will cause the template to register JBoss EAP hosts to an existing Red Hat Satellite Server. Further configuration may be necessary after deployment.",
+                            "link": {
+                                "label": "Learn more",
+                                "uri": "https://access.redhat.com/products/red-hat-satellite"
+                            }
+                        }
+                    },
+                    {
+                        "name": "connectSatellite",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Connect to an existing Red Hat Satellite Server?",
+                        "defaultValue": "No",
+                        "toolTip": "Select 'Yes' to register JBoss EAP hosts created in preview step to an existing Red Hat.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": true
+                                },
+                                {
+                                    "label": "No",
+                                    "value": false
+                                }
+                            ],
+                            "required": false
+                        }
+                    },
+                    {
+                        "name": "satelliteActivationKey",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+                        "label": "The template will need the activation key to register the JBoss EAP host to the Red Hat Satellite server.",
+                        "toolTip": "Activation key",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^.{1,}$",
+                            "validationMessage": "Cannot be empty."
+                        }
+                    },
+                    {
+                        "name": "satelliteOrgName",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+                        "label": "The template will need the Organization name to register the JBoss EAP host to the Red Hat Satellite server.",
+                        "toolTip": "Organization name",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^.{1,}$",
+                            "validationMessage": "Cannot be empty."
+                        }
+                    },
+                    {
+                        "name": "satelliteFqdn",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+                        "label": "The template will need the Fully Qualified Domain Name of Satellite Server virtual machine.",
+                        "toolTip": "Fully Qualified Domain Name of Satellite Sever VM",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^.{1,}$",
+                            "validationMessage": "Cannot be empty."
+                        }
+                    }
+				]
+            },
+            {
                 "name": "jbossEAPSettings",
                 "label": "JBoss EAP Settings",
                 "subLabel": {
@@ -315,6 +394,7 @@
                     {
                         "name": "rhsmUserName",
                         "type": "Microsoft.Common.TextBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
                         "label": "RHSM username",
                         "constraints": {
                             "required": true,
@@ -330,7 +410,7 @@
                             "password": "RHSM password",
                             "confirmPassword": "Confirm password"
                         },
-                        "visible": true,
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
                         "toolTip": "Provide Password for  Red Hat subscription Manager",
                         "options": {
                             "hideConfirmation": false
@@ -342,6 +422,7 @@
                     {
                         "name": "rhsmPoolEAP",
                         "type": "Microsoft.Common.TextBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
                         "label": "RHSM Pool ID with EAP entitlement",
                         "toolTip": "Red Hat Subscription Manager Pool ID (Should have EAP entitlement)",
                         "constraints": {
@@ -353,6 +434,7 @@
                     {
                         "name": "rhsmPoolRHEL",
                         "type": "Microsoft.Common.TextBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
                         "label": "RHSM Pool ID with RHEL entitlement",
                         "toolTip": "Red Hat Subscription Manager Pool ID (Should have RHEL entitlement)",
                         "constraints": {
@@ -394,7 +476,11 @@
             "rhsmUserName": "[steps('jbossEAPSettings').rhsmUserName]",
             "rhsmPassword": "[steps('jbossEAPSettings').rhsmPassword]",
             "rhsmPoolEAP": "[steps('jbossEAPSettings').rhsmPoolEAP]",
-            "rhsmPoolRHEL": "[steps('jbossEAPSettings').rhsmPoolRHEL]"
+            "rhsmPoolRHEL": "[steps('jbossEAPSettings').rhsmPoolRHEL]",
+            "connectSatellite": "[steps('satelliteServerSettings').connectSatellite]",
+            "satelliteActivationKey": "[steps('satelliteServerSettings').satelliteActivationKey]",
+            "satelliteOrgName": "[steps('satelliteServerSettings').satelliteOrgName]",
+            "satelliteFqdn": "[steps('satelliteServerSettings').satelliteFqdn]"
         }
     }
 }

--- a/eap74-rhel8-byos-vmss/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-byos-vmss/src/main/bicep/mainTemplate.bicep
@@ -25,17 +25,17 @@ param jbossEAPUserName string
 param jbossEAPPassword string
 
 @description('User name for Red Hat subscription Manager')
-param rhsmUserName string
+param rhsmUserName string = newGuid()
 
 @description('Password for Red Hat subscription Manager')
 @secure()
-param rhsmPassword string
+param rhsmPassword string = newGuid()
 
 @description('Red Hat Subscription Manager Pool ID (Should have EAP entitlement)')
-param rhsmPoolEAP string
+param rhsmPoolEAP string = newGuid()
 
 @description('Red Hat Subscription Manager Pool ID (Should have RHEL entitlement). Mandartory if you select the BYOS RHEL OS License Type')
-param rhsmPoolRHEL string = ''
+param rhsmPoolRHEL string = newGuid()
 
 @allowed([
   'on'
@@ -112,6 +112,18 @@ param artifactsLocation string = deployment().properties.templateLink.uri
 @description('The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated')
 @secure()
 param artifactsLocationSasToken string = ''
+
+@description('Connect to an existing Red Hat Satellite Server.')
+param connectSatellite bool = false
+
+@description('Red Hat Satellite Server activation key.')
+param satelliteActivationKey string = ''
+
+@description('Red Hat Satellite Server organization name.')
+param satelliteOrgName string = ''
+
+@description('Red Hat Satellite Server VM FQDN name.')
+param satelliteFqdn string = ''
 
 var containerName = 'eapblobcontainer'
 var eapStorageAccountName_var = 'jbosstrg${uniqueString(resourceGroup().id)}'
@@ -291,7 +303,7 @@ resource vmssInstanceName 'Microsoft.Compute/virtualMachineScaleSets@2021-03-01'
                 ]
               }
               protectedSettings: {
-                commandToExecute: 'sh jbosseap-setup-redhat.sh ${scriptArgs} \'${jbossEAPUserName}\' \'${base64(jbossEAPPassword)}\' \'${rhsmUserName}\' \'${base64(rhsmPassword)}\' \'${rhsmPoolEAP}\' \'${eapStorageAccountName_var}\' \'${containerName}\' \'${base64(listKeys(eapStorageAccountName.id, '2021-04-01').keys[0].value)}\' \'${rhsmPoolRHEL}\''
+                commandToExecute: 'sh jbosseap-setup-redhat.sh ${scriptArgs} \'${jbossEAPUserName}\' \'${base64(jbossEAPPassword)}\' \'${rhsmUserName}\' \'${base64(rhsmPassword)}\' \'${rhsmPoolEAP}\' \'${eapStorageAccountName_var}\' \'${containerName}\' \'${base64(listKeys(eapStorageAccountName.id, '2021-04-01').keys[0].value)}\' \'${rhsmPoolRHEL}\' \'${connectSatellite}\' \'${base64(satelliteActivationKey)}\' \'${base64(satelliteOrgName)}\' \'${satelliteFqdn}\''
               }
             }
           }

--- a/eap74-rhel8-byos-vmss/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-byos-vmss/src/main/scripts/jbosseap-setup-redhat.sh
@@ -52,6 +52,12 @@ STORAGE_ACCOUNT_NAME=${14}
 CONTAINER_NAME=${15}
 STORAGE_ACCESS_KEY=$(echo "${16}" | openssl enc -d -base64)
 RHEL_POOL=${17}
+CONNECT_SATELLITE=${18}
+SATELLITE_ACTIVATION_KEY_BASE64=${19}
+SATELLITE_ACTIVATION_KEY=$(echo $SATELLITE_ACTIVATION_KEY_BASE64 | base64 -d)
+SATELLITE_ORG_NAME_BASE64=${20}
+SATELLITE_ORG_NAME=$(echo $SATELLITE_ORG_NAME_BASE64 | base64 -d)
+SATELLITE_VM_FQDN=${21}
 NODE_ID=$(uuidgen | sed 's/-//g' | cut -c 1-23)
 
 echo "JBoss EAP admin user: " ${JBOSS_EAP_USER} | log; flag=${PIPESTATUS[0]}
@@ -76,29 +82,45 @@ echo "iptables-save" | log; flag=${PIPESTATUS[0]}
 sudo iptables-save   | log; flag=${PIPESTATUS[0]}
 ####################### 
 
-echo "Initial JBoss EAP setup" | log; flag=${PIPESTATUS[0]}
-####################### Register to subscription Manager
-echo "Register subscription manager" | log; flag=${PIPESTATUS[0]}
-echo "subscription-manager register --username RHSM_USER --password RHSM_PASSWORD" | log; flag=${PIPESTATUS[0]}
-subscription-manager register --username $RHSM_USER --password $RHSM_PASSWORD --force | log; flag=${PIPESTATUS[0]}
-if [ $flag != 0 ] ; then echo  "ERROR! Red Hat Manager Registration Failed" >&2 log; exit $flag;  fi
-#######################
-####################### Attach EAP Pool
-echo "Subscribing the system to get access to JBoss EAP repos" | log; flag=${PIPESTATUS[0]}
-echo "subscription-manager attach --pool=EAP_POOL" | log; flag=${PIPESTATUS[0]}
-subscription-manager attach --pool=${RHSM_POOL} | log; flag=${PIPESTATUS[0]}
-if [ $flag != 0 ] ; then echo  "ERROR! Pool Attach for JBoss EAP Failed" >&2 log; exit $flag;  fi
-#######################
-####################### Attach RHEL Pool
-echo "Attaching Pool ID for RHEL OS" | log; flag=${PIPESTATUS[0]}
-if [ "$RHSM_POOL" != "$RHEL_POOL" ]; then
-    echo "subscription-manager attach --pool=RHEL_POOL" | log; flag=${PIPESTATUS[0]}
-    subscription-manager attach --pool=${RHEL_POOL}  | log; flag=${PIPESTATUS[0]}
-    if [ $flag != 0 ] ; then echo  "ERROR! Pool Attach for RHEL Failed" >&2 log; exit $flag;  fi
+# Satellite server configuration
+echo "CONNECT_SATELLITE: ${CONNECT_SATELLITE}"
+if [[ "${CONNECT_SATELLITE,,}" == "true" ]]; then
+    ####################### Register to satellite server
+    echo "Configuring Satellite server registration" | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm" | log; flag=${PIPESTATUS[0]}
+    sudo rpm -Uvh http://${SATELLITE_VM_FQDN}/pub/katello-ca-consumer-latest.noarch.rpm | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo subscription-manager clean" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager clean | log; flag=${PIPESTATUS[0]}
+
+    echo "sudo subscription-manager register --org=${SATELLITE_ORG_NAME} --activationkey=${SATELLITE_ACTIVATION_KEY}" | log; flag=${PIPESTATUS[0]}
+    sudo subscription-manager register --org="${SATELLITE_ORG_NAME}" --activationkey="${SATELLITE_ACTIVATION_KEY}" --force | log; flag=${PIPESTATUS[0]}
 else
-    echo "Using the same pool to get access to RHEL repos" | log; flag=${PIPESTATUS[0]}
+    echo "Initial JBoss EAP setup" | log; flag=${PIPESTATUS[0]}
+    ####################### Register to subscription Manager
+    echo "Register subscription manager" | log; flag=${PIPESTATUS[0]}
+    echo "subscription-manager register --username RHSM_USER --password RHSM_PASSWORD" | log; flag=${PIPESTATUS[0]}
+    subscription-manager register --username $RHSM_USER --password $RHSM_PASSWORD --force | log; flag=${PIPESTATUS[0]}
+    if [ $flag != 0 ] ; then echo  "ERROR! Red Hat Manager Registration Failed" >&2 log; exit $flag;  fi
+    #######################
+    ####################### Attach EAP Pool
+    echo "Subscribing the system to get access to JBoss EAP repos" | log; flag=${PIPESTATUS[0]}
+    echo "subscription-manager attach --pool=EAP_POOL" | log; flag=${PIPESTATUS[0]}
+    subscription-manager attach --pool=${RHSM_POOL} | log; flag=${PIPESTATUS[0]}
+    if [ $flag != 0 ] ; then echo  "ERROR! Pool Attach for JBoss EAP Failed" >&2 log; exit $flag;  fi
+    #######################
+    ####################### Attach RHEL Pool
+    echo "Attaching Pool ID for RHEL OS" | log; flag=${PIPESTATUS[0]}
+    if [ "$RHSM_POOL" != "$RHEL_POOL" ]; then
+        echo "subscription-manager attach --pool=RHEL_POOL" | log; flag=${PIPESTATUS[0]}
+        subscription-manager attach --pool=${RHEL_POOL}  | log; flag=${PIPESTATUS[0]}
+        if [ $flag != 0 ] ; then echo  "ERROR! Pool Attach for RHEL Failed" >&2 log; exit $flag;  fi
+    else
+        echo "Using the same pool to get access to RHEL repos" | log; flag=${PIPESTATUS[0]}
+    fi
+    #######################
 fi
-#######################
 
 ####################### Install openjdk: is it needed? it should be installed with eap7.4
 echo "Install openjdk, curl, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}


### PR DESCRIPTION
## Main Changes
* Add new tab to UI, allow users to provide Satellite server's FQDN (need to pre-configured by the users themselves to ensure the networking is viable), Organization Name and Activation Key
* If users enabled the Satellite server feature, register the RHEL hosts to the Satellite, then install JBoss EAP 7.4 (related repos need to be enabled by user themselves through Satellite) and setup the cluster (Both standalone mode and domain mode)

## Test
   * Register to Satellite (Both ARM template and preview offer)
   * Not register to Satellite (Both ARM template and preview offer)
   * [Pipeline validation](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/2794606437)


Signed-off-by: Zheng Chang <zhengchang@microsoft.com>