### PR TITLE
Add step to unregister VMs from RHSM account before deleting

### DIFF
--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -290,6 +290,16 @@ jobs:
                   echo "Cafe is accessible"
                 fi
                 exit 0
+            - name: Unregister before deleting resources
+              if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
+              uses: azure/CLI@v1
+              with:
+                azcliversion: ${{ env.azCliVersion }}
+                inlineScript: |
+                  for ((i = 0; i < numberOfInstances; i++)); do
+                    echo "Unregister ${vmName}${i}"
+                    az vm run-command invoke -g ${domainResourceGroup} -n ${vmName}${i} --command-id RunShellScript --scripts "sudo subscription-manager unregister"
+                  done
             - name: Delete Resource Group
               id: delete-resource-group
               if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
@@ -452,6 +462,16 @@ jobs:
                   echo "eap-session-replication is accessible"
                 fi
                 exit 0
+            - name: Unregister before deleting resources
+              if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
+              uses: azure/CLI@v1
+              with:
+                azcliversion: ${{ env.azCliVersion }}
+                inlineScript: |
+                  for ((i = 0; i < numberOfInstances; i++)); do
+                    echo "Unregister ${vmName}${i}"
+                    az vm run-command invoke -g ${standaloneResourceGroup} -n ${vmName}${i} --command-id RunShellScript --scripts "sudo subscription-manager unregister"
+                  done
             - name: Delete Resource Group
               id: delete-resource-group
               if: ${{ needs.preflight.outputs.isForDemo == 'false' }}

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -225,6 +225,13 @@ jobs:
                   echo "console is accessible"
                 fi
                 exit 0
+            - name: Unregister VM
+              if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
+              uses: azure/CLI@v1
+              with:
+                azcliversion: ${{ env.azCliVersion }}
+                inlineScript: |
+                  az vm run-command invoke -g ${singleResourceGroup} -n ${vmName} --command-id RunShellScript --scripts "sudo subscription-manager unregister"
             - name: Delete Resource Group
               id: delete-resource-group
               if: ${{ needs.preflight.outputs.isForDemo == 'false' }}

--- a/.github/workflows/validate-byos-vmss.yaml
+++ b/.github/workflows/validate-byos-vmss.yaml
@@ -259,6 +259,16 @@ jobs:
                   echo "eap-session-replication is accessible"
                 fi
                 exit 0
+            - name: Unregister before deleting resources
+              if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
+              uses: azure/CLI@v1
+              with:
+                azcliversion: ${{ env.azCliVersion }}
+                inlineScript: |
+                  for ((i = 0; i < numberOfInstances; i++)); do
+                    echo "Unregister VMSS instance ${i}"
+                    az vmss run-command invoke -g ${vmssResourceGroup} -n jbosseap-server${vmssName} --command-id RunShellScript --instance-id ${i} --scripts "sudo subscription-manager unregister"
+                  done
             - name: Delete Resource Group
               id: delete-resource-group
               if: ${{ needs.preflight.outputs.isForDemo == 'false' }}

--- a/.github/workflows/validate-payg-multivm.yaml
+++ b/.github/workflows/validate-payg-multivm.yaml
@@ -288,6 +288,16 @@ jobs:
                   echo "Cafe is accessible"
                 fi
                 exit 0
+            - name: Unregister before deleting resources
+              if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
+              uses: azure/CLI@v1
+              with:
+                azcliversion: ${{ env.azCliVersion }}
+                inlineScript: |
+                  for ((i = 0; i < numberOfInstances; i++)); do
+                    echo "Unregister ${vmName}${i}"
+                    az vm run-command invoke -g ${domainResourceGroup} -n ${vmName}${i} --command-id RunShellScript --scripts "sudo subscription-manager unregister"
+                  done
             - name: Delete Resource Group
               id: delete-resource-group
               if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
@@ -449,6 +459,16 @@ jobs:
                   echo "eap-session-replication is accessible"
                 fi
                 exit 0
+            - name: Unregister before deleting resources
+              if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
+              uses: azure/CLI@v1
+              with:
+                azcliversion: ${{ env.azCliVersion }}
+                inlineScript: |
+                  for ((i = 0; i < numberOfInstances; i++)); do
+                    echo "Unregister ${vmName}${i}"
+                    az vm run-command invoke -g ${standaloneResourceGroup} -n ${vmName}${i} --command-id RunShellScript --scripts "sudo subscription-manager unregister"
+                  done
             - name: Delete Resource Group
               id: delete-resource-group
               if: ${{ needs.preflight.outputs.isForDemo == 'false' }}

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -184,10 +184,10 @@ jobs:
                 azcliversion: ${{ env.azCliVersion }}
                 inlineScript: |
                     # Create NSG rule to allow inbound traffic to port 9990
-                    az network nsg rule create -g ${{ env.singleResourceGroup }} --nsg-name ${{ env.nsgName }} -n rule_9990_22 --priority 100 \
+                    az network nsg rule create -g ${{ env.singleResourceGroup }} --nsg-name ${{ env.nsgName }} -n rule_9990 --priority 100 \
                       --source-address-prefixes '*' --source-port-ranges '*' \
-                      --destination-address-prefixes '*' --destination-port-ranges 9990 22 --access Allow \
-                      --protocol '*' --description "allow 9990 22"
+                      --destination-address-prefixes '*' --destination-port-ranges 9990 --access Allow \
+                      --protocol '*' --description "allow 9990"
                     # Create public IP
                     az network public-ip create --name ${{ env.testPubIpName }} --resource-group ${{ env.singleResourceGroup }}
                     # Query VM NIC name
@@ -221,24 +221,13 @@ jobs:
                   echo "console is accessible"
                 fi
                 exit 0
-            # Fix failure that caused by remote server closed.
-            - name: Restart remote SSH agent
-              run: |
-                  echo "Restart remote SSH agent"
-                  az vm user reset-ssh \
-                    --resource-group $singleResourceGroup \
-                    --name $vmName
-                  sleep 1m
             - name: Unregister VM
               if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
-              run: |
-                  publicip=${{steps.setup_public_lb.outputs.publicip}}
-                  echo "publicip: " $publicip
-                  echo "Unregister VM from RHSM account"
-                  timeout 6m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${publicip} 22
-                  echo install sshpass
-                  sudo apt-get install -y sshpass
-                  sshpass -p ${password} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${adminUsername}@${publicip} 'sudo subscription-manager unregister'
+              uses: azure/CLI@v1
+              with:
+                azcliversion: ${{ env.azCliVersion }}
+                inlineScript: |
+                  az vm run-command invoke -g ${singleResourceGroup} -n ${vmName} --command-id RunShellScript --scripts "sudo subscription-manager unregister"
             - name: Delete Resource Group
               id: delete-resource-group
               if: ${{ needs.preflight.outputs.isForDemo == 'false' }}

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -184,10 +184,10 @@ jobs:
                 azcliversion: ${{ env.azCliVersion }}
                 inlineScript: |
                     # Create NSG rule to allow inbound traffic to port 9990
-                    az network nsg rule create -g ${{ env.singleResourceGroup }} --nsg-name ${{ env.nsgName }} -n rule_9990 --priority 100 \
+                    az network nsg rule create -g ${{ env.singleResourceGroup }} --nsg-name ${{ env.nsgName }} -n rule_9990_22 --priority 100 \
                       --source-address-prefixes '*' --source-port-ranges '*' \
-                      --destination-address-prefixes '*' --destination-port-ranges 9990 --access Allow \
-                      --protocol '*' --description "allow 9990"
+                      --destination-address-prefixes '*' --destination-port-ranges 9990 22 --access Allow \
+                      --protocol '*' --description "allow 9990 22"
                     # Create public IP
                     az network public-ip create --name ${{ env.testPubIpName }} --resource-group ${{ env.singleResourceGroup }}
                     # Query VM NIC name
@@ -221,6 +221,24 @@ jobs:
                   echo "console is accessible"
                 fi
                 exit 0
+            # Fix failure that caused by remote server closed.
+            - name: Restart remote SSH agent
+              run: |
+                  echo "Restart remote SSH agent"
+                  az vm user reset-ssh \
+                    --resource-group $singleResourceGroup \
+                    --name $vmName
+                  sleep 1m
+            - name: Unregister VM
+              if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
+              run: |
+                  publicip=${{steps.setup_public_lb.outputs.publicip}}
+                  echo "publicip: " $publicip
+                  echo "Unregister VM from RHSM account"
+                  timeout 6m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${publicip} 22
+                  echo install sshpass
+                  sudo apt-get install -y sshpass
+                  sshpass -p ${password} -v ssh -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveCountMax=20 -o ServerAliveInterval=15 -o ConnectTimeout=100 -v -tt ${adminUsername}@${publicip} 'sudo subscription-manager unregister'
             - name: Delete Resource Group
               id: delete-resource-group
               if: ${{ needs.preflight.outputs.isForDemo == 'false' }}

--- a/.github/workflows/validate-payg-vmss.yaml
+++ b/.github/workflows/validate-payg-vmss.yaml
@@ -240,6 +240,16 @@ jobs:
                   echo "eap-session-replication is accessible"
                 fi
                 exit 0
+            - name: Unregister before deleting resources
+              if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
+              uses: azure/CLI@v1
+              with:
+                azcliversion: ${{ env.azCliVersion }}
+                inlineScript: |
+                  for ((i = 0; i < numberOfInstances; i++)); do
+                    echo "Unregister VMSS instance ${i}"
+                    az vmss run-command invoke -g ${vmssResourceGroup} -n jbosseap-server${vmssName} --command-id RunShellScript --instance-id ${i} --scripts "sudo subscription-manager unregister"
+                  done
             - name: Delete Resource Group
               id: delete-resource-group
               if: ${{ needs.preflight.outputs.isForDemo == 'false' }}


### PR DESCRIPTION
## Change
This change addresses #105 

To run `subscription-manager unregister` command, we use [az vm run-command invoke](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/run-command) command for single node & multivm offers, and [az vmss run-command invoke](https://docs.microsoft.com/en-us/cli/azure/vmss/run-command?view=azure-cli-latest#az-vmss-run-command-invoke)  command for VMSS offers.


## Test
[Validate payg offer](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/2886807202)
[Validate payg-vmss offer](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/2886949360)
[Validate payg-multivm offer](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/2887002768)
[Validate byos offer](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/2886807505)
[Validate byos-vmss offer](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/2886949137)
[Validate byos-multivm offer](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/2887002060)