### PR TITLE
Support 'Register hosts to existing Satellite server' for eap74-rhel8-payg (single node)

### DIFF
--- a/eap74-rhel8-payg/pom.xml
+++ b/eap74-rhel8-payg/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-payg</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/eap74-rhel8-payg/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg/src/main/arm/createUiDefinition.json
@@ -316,6 +316,85 @@
                 ]
             },
             {
+                "name": "satelliteServerSettings",
+                "label": "Satellite Server Settings",
+                "subLabel": {
+                    "preValidation": "Provide the settings for Satellite Server registration",
+                    "postValidation": "Done"
+                },
+                "bladeTitle": "Satellite Server Settings",
+                "elements": [
+                    {
+                        "name": "connectToSatelliteServer",
+                        "type": "Microsoft.Common.TextBlock",
+                        "visible": true,
+                        "options": {
+                            "text": "Selecting 'Yes' here will cause the template to register JBoss EAP hosts to an existing Red Hat Satellite Server. Further configuration may be necessary after deployment.",
+                            "link": {
+                                "label": "Learn more",
+                                "uri": "https://access.redhat.com/products/red-hat-satellite"
+                            }
+                        }
+                    },
+                    {
+                        "name": "connectSatellite",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Connect to an existing Red Hat Satellite Server?",
+                        "defaultValue": "No",
+                        "toolTip": "Select 'Yes' to register JBoss EAP hosts created in preview step to an existing Red Hat.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": true
+                                },
+                                {
+                                    "label": "No",
+                                    "value": false
+                                }
+                            ],
+                            "required": false
+                        }
+                    },
+                    {
+                        "name": "satelliteActivationKey",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+                        "label": "The template will need the activation key to register the JBoss EAP host to the Red Hat Satellite server.",
+                        "toolTip": "Activation key",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^.{1,}$",
+                            "validationMessage": "Cannot be empty."
+                        }
+                    },
+                    {
+                        "name": "satelliteOrgName",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+                        "label": "The template will need the Organization name to register the JBoss EAP host to the Red Hat Satellite server.",
+                        "toolTip": "Organization name",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^.{1,}$",
+                            "validationMessage": "Cannot be empty."
+                        }
+                    },
+                    {
+                        "name": "satelliteFqdn",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[steps('satelliteServerSettings').connectSatellite]",
+                        "label": "The template will need the Fully Qualified Domain Name of Satellite Server virtual machine.",
+                        "toolTip": "Fully Qualified Domain Name of Satellite Sever VM",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^.{1,}$",
+                            "validationMessage": "Cannot be empty."
+                        }
+                    }
+				]
+            },
+            {
                 "name": "jbossEAPSettings",
                 "label": "JBoss EAP Settings",
                 "subLabel": {
@@ -353,6 +432,7 @@
                     {
                         "name": "rhsmUserName",
                         "type": "Microsoft.Common.TextBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
                         "label": "RHSM username",
                         "constraints": {
                             "required": true,
@@ -368,7 +448,7 @@
                             "password": "RHSM password",
                             "confirmPassword": "Confirm password"
                         },
-                        "visible": true,
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
                         "toolTip":"Provide Password for  Red Hat subscription Manager",
                         "options": {
                             "hideConfirmation": false
@@ -380,6 +460,7 @@
                     {
                         "name": "rhsmPoolEAP",
                         "type": "Microsoft.Common.TextBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
                         "label": "RHSM Pool ID with EAP entitlement",
                         "toolTip": "Red Hat Subscription Manager Pool ID (Should have EAP entitlement)",
                         "constraints": {
@@ -419,7 +500,11 @@
             "jbossEAPPassword": "[steps('jbossEAPSettings').jbossEAPPassword]",
             "rhsmUserName": "[steps('jbossEAPSettings').rhsmUserName]",
             "rhsmPassword": "[steps('jbossEAPSettings').rhsmPassword]",
-            "rhsmPoolEAP": "[steps('jbossEAPSettings').rhsmPoolEAP]"
+            "rhsmPoolEAP": "[steps('jbossEAPSettings').rhsmPoolEAP]",
+            "connectSatellite": "[steps('satelliteServerSettings').connectSatellite]",
+            "satelliteActivationKey": "[steps('satelliteServerSettings').satelliteActivationKey]",
+            "satelliteOrgName": "[steps('satelliteServerSettings').satelliteOrgName]",
+            "satelliteFqdn": "[steps('satelliteServerSettings').satelliteFqdn]"
         }
     }
 }

--- a/eap74-rhel8-payg/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-payg/src/main/bicep/mainTemplate.bicep
@@ -83,7 +83,7 @@ param rhsmPassword string = newGuid()
 @description('Red Hat Subscription Manager Pool ID (Should have EAP entitlement)')
 @minLength(32)
 @maxLength(32)
-param rhsmPoolEAP string = newGuid()
+param rhsmPoolEAP string = take(newGuid(), 32)
 
 @description('The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated')
 param artifactsLocation string = deployment().properties.templateLink.uri

--- a/eap74-rhel8-payg/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-payg/src/main/bicep/mainTemplate.bicep
@@ -74,16 +74,16 @@ param jbossEAPUserName string
 param jbossEAPPassword string
 
 @description('User name for Red Hat subscription Manager')
-param rhsmUserName string
+param rhsmUserName string = newGuid()
 
 @description('Password for Red Hat subscription Manager')
 @secure()
-param rhsmPassword string
+param rhsmPassword string = newGuid()
 
 @description('Red Hat Subscription Manager Pool ID (Should have EAP entitlement)')
 @minLength(32)
 @maxLength(32)
-param rhsmPoolEAP string
+param rhsmPoolEAP string = newGuid()
 
 @description('The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated')
 param artifactsLocation string = deployment().properties.templateLink.uri
@@ -91,6 +91,18 @@ param artifactsLocation string = deployment().properties.templateLink.uri
 @description('The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated')
 @secure()
 param artifactsLocationSasToken string = ''
+
+@description('Connect to an existing Red Hat Satellite Server.')
+param connectSatellite bool = false
+
+@description('Red Hat Satellite Server activation key.')
+param satelliteActivationKey string = ''
+
+@description('Red Hat Satellite Server organization name.')
+param satelliteOrgName string = ''
+
+@description('Red Hat Satellite Server VM FQDN name.')
+param satelliteFqdn string = ''
 
 var nicName_var = '${uniqueString(resourceGroup().id)}-nic'
 var networkSecurityGroupName_var = 'jbosseap-nsg'
@@ -230,7 +242,7 @@ resource vmName_jbosseap_setup_extension 'Microsoft.Compute/virtualMachines/exte
       ]
     }
     protectedSettings: {
-      commandToExecute: 'sh jbosseap-setup-redhat.sh \'${jbossEAPUserName}\' \'${base64(jbossEAPPassword)}\' \'${rhsmUserName}\' \'${base64(rhsmPassword)}\' \'${rhsmPoolEAP}\''
+      commandToExecute: 'sh jbosseap-setup-redhat.sh \'${jbossEAPUserName}\' \'${base64(jbossEAPPassword)}\' \'${rhsmUserName}\' \'${base64(rhsmPassword)}\' \'${rhsmPoolEAP}\' \'${connectSatellite}\' \'${base64(satelliteActivationKey)}\' \'${base64(satelliteOrgName)}\' \'${satelliteFqdn}\''
     }
   }
 }


### PR DESCRIPTION
## Main Changes
* Add new tab to UI, allow users to provide Satellite server's FQDN (need to pre-configured by the users themselves to ensure the networking is viable), Organization Name and Activation Key
* If users enabled the Satellite server feature, register the RHEL hosts to the Satellite, then install JBoss EAP 7.4 (related repos need to be enabled by user themselves through Satellite) and setup the cluster (Both standalone mode and domain mode)

## Test
   * Register/Not register to Satellite preview offer
   * [Pipeline validation](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/2900766258)


Signed-off-by: Zheng Chang <zhengchang@microsoft.com>