### PR TITLE
Workaround arm-ttk complain: Parameters property must exist in the template

### DIFF
--- a/.github/workflows/build-artifact-byos-multivm.yaml
+++ b/.github/workflows/build-artifact-byos-multivm.yaml
@@ -70,7 +70,7 @@ jobs:
             - name: Build ${{ env.offerName }}
               run: |
                 cd ${{env.repoName}}/${{ env.offerName }}
-                mvn -Pbicep -Passembly clean install
+                mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests
             - name: Generate artifact file name and path
               id: artifact_file
               run: |

--- a/.github/workflows/build-artifact-byos-single.yaml
+++ b/.github/workflows/build-artifact-byos-single.yaml
@@ -70,7 +70,7 @@ jobs:
             - name: Build ${{ env.offerName }}
               run: |
                 cd ${{env.repoName}}/${{ env.offerName }}
-                mvn -Pbicep -Passembly clean install
+                mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests
             - name: Generate artifact file name and path
               id: artifact_file
               run: |

--- a/.github/workflows/build-artifact-byos-vmss.yaml
+++ b/.github/workflows/build-artifact-byos-vmss.yaml
@@ -70,7 +70,7 @@ jobs:
             - name: Build ${{ env.offerName }}
               run: |
                 cd ${{env.repoName}}/${{ env.offerName }}
-                mvn -Pbicep -Passembly clean install
+                mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests
             - name: Generate artifact file name and path
               id: artifact_file
               run: |

--- a/.github/workflows/build-artifact-payg-multivm.yaml
+++ b/.github/workflows/build-artifact-payg-multivm.yaml
@@ -70,7 +70,7 @@ jobs:
             - name: Build ${{ env.offerName }}
               run: |
                 cd ${{env.repoName}}/${{ env.offerName }}
-                mvn -Pbicep -Passembly clean install
+                mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests
             - name: Generate artifact file name and path
               id: artifact_file
               run: |

--- a/.github/workflows/build-artifact-payg-single.yaml
+++ b/.github/workflows/build-artifact-payg-single.yaml
@@ -70,7 +70,7 @@ jobs:
             - name: Build ${{ env.offerName }}
               run: |
                 cd ${{env.repoName}}/${{ env.offerName }}
-                mvn -Pbicep -Passembly clean install
+                mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests
             - name: Generate artifact file name and path
               id: artifact_file
               run: |

--- a/.github/workflows/build-artifact-payg-vmss.yaml
+++ b/.github/workflows/build-artifact-payg-vmss.yaml
@@ -70,7 +70,7 @@ jobs:
             - name: Build ${{ env.offerName }}
               run: |
                 cd ${{env.repoName}}/${{ env.offerName }}
-                mvn -Pbicep -Passembly clean install
+                mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests
             - name: Generate artifact file name and path
               id: artifact_file
               run: |

--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
     azCliVersion: 2.30.0
-    refArmttk: 90e8e5cde786cd8b0c358c847ee9d0203e11e726
+    refArmttk: bad2965565e2e69318039bc15c2496844d55a59d
     refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
     location: eastus

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
     azCliVersion: 2.30.0
-    refArmttk: 90e8e5cde786cd8b0c358c847ee9d0203e11e726
+    refArmttk: bad2965565e2e69318039bc15c2496844d55a59d
     refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
     location: eastus

--- a/.github/workflows/validate-byos-vmss.yaml
+++ b/.github/workflows/validate-byos-vmss.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
     azCliVersion: 2.30.0
-    refArmttk: 90e8e5cde786cd8b0c358c847ee9d0203e11e726
+    refArmttk: bad2965565e2e69318039bc15c2496844d55a59d
     refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
     location: eastus

--- a/.github/workflows/validate-payg-multivm.yaml
+++ b/.github/workflows/validate-payg-multivm.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
     azCliVersion: 2.30.0
-    refArmttk: 90e8e5cde786cd8b0c358c847ee9d0203e11e726
+    refArmttk: bad2965565e2e69318039bc15c2496844d55a59d
     refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
     location: eastus

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
     azCliVersion: 2.30.0
-    refArmttk: 90e8e5cde786cd8b0c358c847ee9d0203e11e726
+    refArmttk: bad2965565e2e69318039bc15c2496844d55a59d
     refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
     location: eastus

--- a/.github/workflows/validate-payg-vmss.yaml
+++ b/.github/workflows/validate-payg-vmss.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
     azCliVersion: 2.30.0
-    refArmttk: 90e8e5cde786cd8b0c358c847ee9d0203e11e726
+    refArmttk: bad2965565e2e69318039bc15c2496844d55a59d
     refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
     location: eastus

--- a/eap74-rhel8-byos-multivm/pom.xml
+++ b/eap74-rhel8-byos-multivm/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-byos-multivm</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/eap74-rhel8-byos-multivm/src/main/bicep/modules/_pids/_empty.bicep
+++ b/eap74-rhel8-byos-multivm/src/main/bicep/modules/_pids/_empty.bicep
@@ -13,3 +13,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+// Workaround to arm-ttk complain: Parameters property must exist in the template
+param name string = 'This is an empty deployment'
+
+output name string = name

--- a/eap74-rhel8-byos-vmss/pom.xml
+++ b/eap74-rhel8-byos-vmss/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-byos-vmss</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/eap74-rhel8-byos-vmss/src/main/bicep/modules/_pids/_empty.bicep
+++ b/eap74-rhel8-byos-vmss/src/main/bicep/modules/_pids/_empty.bicep
@@ -13,3 +13,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+// Workaround to arm-ttk complain: Parameters property must exist in the template
+param name string = 'This is an empty deployment'
+
+output name string = name

--- a/eap74-rhel8-byos/pom.xml
+++ b/eap74-rhel8-byos/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-byos</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
@@ -126,7 +126,7 @@ var linuxConfiguration = {
 }
 
 module partnerCenterPid './modules/_pids/_empty.bicep' = {
-  name: 'pid-1879addb-1fa9-4225-8bd2-6d0a1ffc5dc0-partnercenter'
+  name: 'pid-e9412731-57c2-4e6a-9825-061ad30337c0-partnercenter'
   params: {}
 }
 

--- a/eap74-rhel8-byos/src/main/bicep/modules/_pids/_empty.bicep
+++ b/eap74-rhel8-byos/src/main/bicep/modules/_pids/_empty.bicep
@@ -13,3 +13,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+// Workaround to arm-ttk complain: Parameters property must exist in the template
+param name string = 'This is an empty deployment'
+
+output name string = name

--- a/eap74-rhel8-payg-multivm/pom.xml
+++ b/eap74-rhel8-payg-multivm/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-payg-multivm</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     

--- a/eap74-rhel8-payg-multivm/src/main/bicep/modules/_pids/_empty.bicep
+++ b/eap74-rhel8-payg-multivm/src/main/bicep/modules/_pids/_empty.bicep
@@ -13,3 +13,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+// Workaround to arm-ttk complain: Parameters property must exist in the template
+param name string = 'This is an empty deployment'
+
+output name string = name

--- a/eap74-rhel8-payg-vmss/pom.xml
+++ b/eap74-rhel8-payg-vmss/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-payg-vmss</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/eap74-rhel8-payg-vmss/src/main/bicep/modules/_pids/_empty.bicep
+++ b/eap74-rhel8-payg-vmss/src/main/bicep/modules/_pids/_empty.bicep
@@ -13,3 +13,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+// Workaround to arm-ttk complain: Parameters property must exist in the template
+param name string = 'This is an empty deployment'
+
+output name string = name

--- a/eap74-rhel8-payg/pom.xml
+++ b/eap74-rhel8-payg/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-payg</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/eap74-rhel8-payg/src/main/bicep/modules/_pids/_empty.bicep
+++ b/eap74-rhel8-payg/src/main/bicep/modules/_pids/_empty.bicep
@@ -13,3 +13,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+// Workaround to arm-ttk complain: Parameters property must exist in the template
+param name string = 'This is an empty deployment'
+
+output name string = name


### PR DESCRIPTION
## Change
* Add `param` and `output` fields as workaround for Partner Center arm-ttk error
* Update arm-ttk reference
* Increase pom version
## Test
Run `mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests` locally against Partner Center's arm-ttk.