### PR TITLE
Fix service principal role assignment & deletion bug

### DIFF
--- a/.github/workflows/setup-cluster-credentials.sh
+++ b/.github/workflows/setup-cluster-credentials.sh
@@ -179,6 +179,8 @@ SUBSCRIPTION_ID=$(az account show --query id --output tsv --only-show-errors)
 ### AZ ACTION CREATE
 
 SERVICE_PRINCIPAL=$(az ad sp create-for-rbac --name ${SERVICE_PRINCIPAL_NAME} --role="Contributor" --scopes="/subscriptions/${SUBSCRIPTION_ID}" --sdk-auth --only-show-errors | base64 -w0)
+SP_ID=$( az ad sp list --display-name $SERVICE_PRINCIPAL_NAME --query [0].id -o tsv)
+az role assignment create --assignee ${SP_ID} --role "User Access Administrator"
 AZURE_CREDENTIALS=$(echo $SERVICE_PRINCIPAL | base64 -d)
 
 msg "${GREEN}(4/4) Create secrets in GitHub"

--- a/.github/workflows/tear-down-cluster-credentials.sh
+++ b/.github/workflows/tear-down-cluster-credentials.sh
@@ -47,7 +47,7 @@ SERVICE_PRINCIPAL_NAME=${DISAMBIG_PREFIX}sp
 # Execute commands
 msg "${GREEN}(1/3) Delete service principal ${SERVICE_PRINCIPAL_NAME}"
 SUBSCRIPTION_ID=$(az account show --query id --output tsv --only-show-errors)
-SP_OBJECT_ID_ARRAY=$(az ad sp list --display-name ${SERVICE_PRINCIPAL_NAME} --query "[].objectId") || true
+SP_OBJECT_ID_ARRAY=$(az ad sp list --display-name ${SERVICE_PRINCIPAL_NAME} --query "[].id") || true
 # remove whitespace
 SP_OBJECT_ID_ARRAY=$(echo ${SP_OBJECT_ID_ARRAY} | xargs) || true
 SP_OBJECT_ID_ARRAY=${SP_OBJECT_ID_ARRAY//[/}


### PR DESCRIPTION
## Problem
Azure Credential generated from `setup-cluster-credentials.sh` missed required Azure Role to complete the pipelines.

## Root cause
After removing UAMI from multimv offers (BYOS and PAYG), the service principal must have either **Owner** role or **Contributor + User Access Administrator** roles.

## Change
* Assign **User Access Administrator** role to created service principal.
* Fix service principal deletion

## Test steps in forked repo
1. Run `setup-cluster-credentials.sh` to generate GitHub Secrets
2. Run pipelines:
    * [Validate payg-multivm offer](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/3110468056)
    * [Validate byos-multivm offer](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/3110341078)
4. Run `tear-down-cluster-credentials.sh` to remove GitHub Secrets


Signed-off-by: Zheng Chang <zhengchang@microsoft.com>