### PR TITLE
Support configurable OpenJDK versions in PAYG single node offer

### DIFF
--- a/.github/workflows/build-artifact-payg-single.yaml
+++ b/.github/workflows/build-artifact-payg-single.yaml
@@ -13,8 +13,6 @@ on:
   # curl --verbose -X POST https://api.github.com/repos/<github_user>/rhel-jboss-templates/dispatches -H 'Accept: application/vnd.github.everest-preview+json' -H 'Authorization: token <personal_access_token>' --data '{"event_type": "payg-single-package", "client_payload": {"ref": "refs/heads/main"}}'
 
 env:
-    refArmttk: bad2965565e2e69318039bc15c2496844d55a59d
-    refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
     azCliVersion: 2.30.0
     location: eastus
     offerName: "eap74-rhel8-payg"
@@ -25,6 +23,14 @@ jobs:
     preflight:
         runs-on: ubuntu-latest
         steps:
+            - name: Get versions of external dependencies
+              run: |
+                curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
+                source external-deps-versions.properties
+                echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
+                echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
+                echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
+                echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
             - name: Setup environment variables
               id: setup-env-variables-based-on-dispatch-event
               run: |
@@ -38,10 +44,11 @@ jobs:
                 fi
                 echo "##[set-output name=ref;]${ref}"
                 echo "ref=${ref}" >> $GITHUB_ENV
-            - name: Set up JDK 1.8
-              uses: actions/setup-java@v1
+            - name: Set up JDK 11
+              uses: actions/setup-java@v3
               with:
-                java-version: 1.8
+                distribution: 'temurin'
+                java-version: '11'
             - name: Set up bicep
               run: |
                 curl -Lo bicep https://github.com/Azure/bicep/releases/download/v0.8.9/bicep-linux-x64
@@ -49,13 +56,13 @@ jobs:
                 sudo mv ./bicep /usr/local/bin/bicep
                 bicep --version
             - name: Checkout azure-javaee-iaas
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: Azure/azure-javaee-iaas
                 path: azure-javaee-iaas
                 ref: ${{ env.refJavaee }}
             - name: Checkout arm-ttk
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: Azure/arm-ttk
                 path: arm-ttk
@@ -63,7 +70,7 @@ jobs:
             - name: Build azure-javaee-iaas
               run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
             - name: Checkout ${{ env.repoName }}
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 path: ${{ env.repoName }}
                 ref: ${{ env.ref }}

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -10,8 +10,6 @@ on:
 
 env:
     azCliVersion: 2.30.0
-    refArmttk: bad2965565e2e69318039bc15c2496844d55a59d
-    refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
     location: eastus
     singleResourceGroup: single-${{ github.run_id }}-${{ github.run_number }}
@@ -37,24 +35,33 @@ jobs:
           isForDemo: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.isForDemo }}
         runs-on: ubuntu-latest
         steps:
-            - name: Set up JDK 1.8
-              uses: actions/setup-java@v1
+            - name: Get versions of external dependencies
+              run: |
+                curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
+                source external-deps-versions.properties
+                echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
+                echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
+                echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
+                echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
+            - name: Set up JDK 11
+              uses: actions/setup-java@v3
               with:
-                java-version: 1.8
+                distribution: 'temurin'
+                java-version: '11'
             - name: Set up bicep
               run: |
-                curl -Lo bicep https://github.com/Azure/bicep/releases/download/v0.4.613/bicep-linux-x64
+                curl -Lo bicep https://github.com/Azure/bicep/releases/download/${{ env.bicepVersion }}/bicep-linux-x64
                 chmod +x ./bicep
                 sudo mv ./bicep /usr/local/bin/bicep
                 bicep --version
             - name: Checkout azure-javaee-iaas
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: Azure/azure-javaee-iaas
                 path: azure-javaee-iaas
                 ref: ${{ env.refJavaee }}
             - name: Checkout arm-ttk
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: Azure/arm-ttk
                 path: arm-ttk
@@ -62,7 +69,7 @@ jobs:
             - name: Build azure-javaee-iaas
               run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
             - name: Checkout rhel-jboss-templates
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: ${{env.gitUserName}}/rhel-jboss-templates
                 path: rhel-jboss-templates
@@ -96,7 +103,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout rhel-jboss-templates
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: ${{env.gitUserName}}/rhel-jboss-templates
                 path: rhel-jboss-templates
@@ -235,7 +242,7 @@ jobs:
                   echo "delete... " $singleResourceGroup
                   az group delete --yes --no-wait --verbose --name $singleResourceGroup
             - name: Checkout rhel-jboss-templates
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: ${{env.gitUserName}}/rhel-jboss-templates
                 path: rhel-jboss-templates

--- a/eap74-rhel8-payg/pom.xml
+++ b/eap74-rhel8-payg/pom.xml
@@ -5,12 +5,12 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-payg</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.16</version>
+        <version>1.0.18</version>
         <relativePath></relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/eap74-rhel8-payg/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg/src/main/arm/createUiDefinition.json
@@ -5,22 +5,55 @@
     "parameters": {
         "basics": [
             {
-                "name": "vmName",
-                "type": "Microsoft.Common.TextBox",
-                "label": "Virtual Machine name",
-                "toolTip": "The name of the Virtual Machine",
+                "name": "vmSize",
+                "type": "Microsoft.Compute.SizeSelector",
+                "label": "Virtual machine size",
+                "toolTip": "The size of virtual machine to provision",
+                "recommendedSizes": [
+                    "Standard_DS2_v2",
+                    "Standard_DS3_v2",
+                    "Standard_DS4_v2",
+                    "Standard_E2S_v3",
+                    "Standard_E4S_v3",
+                    "Standard_E8S_v3",
+                    "Standard_F2S_v2",
+                    "Standard_F4S_v2",
+                    "Standard_F8S_v2" 
+                ],
+                "osPlatform": "Linux",
+                "count": "1"
+            },
+            {
+                "name": "jdkVersion",
+                "type": "Microsoft.Common.DropDown",
+                "label": "JDK version",
+                "defaultValue": "OpenJDK 17",
+                "toolTip": "Choose JDK version.",
                 "constraints": {
-                    "required": true,
-                    "regex": "^[a-z0-9A-Z-]{3,79}$",
-                    "validationMessage": "The VM Name must be between 3 and 79 characters long and contain letters, numbers and hyphens only."
-                }
+                    "allowedValues": [
+                        {
+                            "label": "OpenJDK 8",
+                            "value": "openjdk8"
+                        },
+                        {
+                            "label": "OpenJDK 11",
+                            "value": "openjdk11"
+                        },
+                        {
+                            "label": "OpenJDK 17",
+                            "value": "openjdk17"
+                        }
+                    ],
+                    "required": true
+                },
+                "visible": true
             },
             {
                 "name": "adminUsername",
-                "type": "Microsoft.Compute.UserNameTextBox",
+                "type": "Microsoft.Common.TextBox",
                 "label": "Username",
+                "defaultValue": "jbossuser",
                 "toolTip": "Linux VM user account name",
-                "osPlatform": "Linux",
                 "constraints": {
                     "required": true,
                     "regex": "^[a-zA-Z]+[a-zA-Z0-9_-]{1,64}$",
@@ -48,6 +81,185 @@
                     "hideConfirmation": false
                 },
                 "osPlatform": "Linux"
+            },
+            {
+                "name": "basicsOptional",
+                "type": "Microsoft.Common.Section",
+                "label": "Optional Basic Configuration",
+                "elements": [
+                    {
+                        "name": "basicsOptionalAcceptDefaults",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Accept defaults for optional configuration?",
+                        "defaultValue": "Yes",
+                        "toolTip": "Select 'No' to edit optional basic configuration.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": "false"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "true"
+                                }
+                            ],
+                            "required": true
+                        }
+                    },
+                    {
+                        "name": "vmName",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "Virtual Machine name",
+                        "defaultValue": "jbossvm",
+                        "toolTip": "The name of the Virtual Machine",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-z0-9A-Z-]{3,79}$",
+                            "validationMessage": "The VM Name must be between 3 and 79 characters long and contain letters, numbers and hyphens only."
+                        },
+                        "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
+                    },
+                    {
+                        "name": "bootDiagnostics",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Boot diagnostics",
+                        "defaultValue": "off",
+                        "toolTip": "Capture serial console outputs and screenshots of the virtual machine running on a host to help diagnose startup issues",
+                        "constraints": {
+                          "allowedValues": [
+                            {
+                              "label": "on",
+                              "value": "on"
+                            },
+                            {
+                              "label": "off",
+                              "value": "off"
+                            }
+                          ],
+                          "required": true
+                        },
+                        "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
+                    },
+                    {
+						"name": "storageNewOrExisting",
+						"type": "Microsoft.Common.DropDown",
+						"label": "Storage Account",
+						"defaultValue": "New",
+						"toolTip": "Select new or existing Storage account",
+						"constraints": {
+							"allowedValues": [
+								{
+									"label": "Existing",
+									"value": "Existing"
+								},
+								{
+									"label": "New",
+									"value": "New"
+								}
+							],
+							"required": true
+						},
+						"visible": "[and(bool(basics('basicsOptional').basicsOptionalAcceptDefaults), equals(basics('basicsOptional').bootDiagnostics, 'on'))]"
+					},
+                    {
+                        "name": "armApiControl",
+                        "type": "Microsoft.Solutions.ArmApiControl",
+                        "request": {
+                          "method": "GET",
+                          "path": "[concat(subscription().id, '/providers/Microsoft.Storage/storageAccounts?api-version=2021-04-01')]"
+                        },
+                        "visible": "[and(bool(basics('basicsOptional').basicsOptionalAcceptDefaults), equals(basics('basicsOptional').storageNewOrExisting, 'Existing'))]"
+                      },
+                      {
+                        "name": "existingStorageAccount",
+                        "type": "Microsoft.Common.DropDown",
+                        "label": "Available storage accounts",
+                        "toolTip": "Select a storage account from the existing list",
+                        "constraints": {
+                          "allowedValues": "[filter(map(basics('basicsOptional').armApiControl.value, (item) => parse(concat('{\"label\":\"', concat(item.name,' (',item.kind,')'), '\",\"value\":\"', item.name, '\",\"kind\":\"', item.kind, '\",\"location\":\"', item.location, '\",\"tier\":\"', item.sku.tier, '\"}'))), (item) => and(and(not(contains(toLower(item.kind),'blob')),equals(location(),item.location)),equals('Standard',item.tier)))]",
+                          "required": true
+                        },
+                        "visible": "[and(bool(basics('basicsOptional').basicsOptionalAcceptDefaults), equals(basics('basicsOptional').storageNewOrExisting, 'Existing'))]"
+                    },
+					{
+                        "name": "nameApi",
+                        "type": "Microsoft.Solutions.ArmApiControl",
+                        "request": {
+                        "method": "POST",
+                        "path": "[concat(subscription().id,'/providers/Microsoft.Storage/checkNameAvailability?api-version=2019-06-01')]",
+                        "body":  {
+                            "name": "[basics('basicsOptional').storageAccountName]",
+                            "type": "Microsoft.Storage/storageAccounts"
+                            }
+                        },
+                        "visible": "[and(bool(basics('basicsOptional').basicsOptionalAcceptDefaults), equals(basics('basicsOptionalAcceptDefaults').storageNewOrExisting, 'New'))]"
+                    },
+                    {
+                        "name": "storageAccountName",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "Storage Account Name",
+                        "defaultValue": "[concat('jbosssa', substring(guid(), 0, 6))]",
+                        "toolTip": "Name of the storage account",
+                        "constraints": {
+                        "validations": [
+                            {
+                                "regex": "^[a-z0-9]{3,24}$",
+                                "message": "Storage account name should be between 3 and 24 characters and only contain lowercase letters and numbers"
+                            },
+                            {
+                                "isValid": "[not(equals(basics('basicsOptional').nameApi.nameAvailable, false))]",
+                                "message": "[concat('The storage account name \"',basics('basicsOptional').storageAccountName, '\" is unavailable or already taken')]"
+                            }
+                        ],
+                        "required": true
+                        },
+                        "visible": "[and(bool(basics('basicsOptional').basicsOptionalAcceptDefaults), equals(basics('basicsOptional').storageNewOrExisting, 'New'))]"
+                    },
+					{
+						"name": "storageAccountKind",
+						"type": "Microsoft.Common.DropDown",
+						"label": "Storage Account Kind",
+						"defaultValue": "Storage",
+						"toolTip": "General purpose storage accounts provide storage for blobs, files, tables, and queues in a unified account. Choose an access tier that matches your storage needs.",
+						"constraints": {
+							"allowedValues": [
+								{
+									"label": "Storage",
+									"value": "Storage"
+								},
+								{
+									"label": "StorageV2",
+									"value": "StorageV2"
+								}
+							],
+							"required": true
+						},
+						"visible": "[and(bool(basics('basicsOptional').basicsOptionalAcceptDefaults), equals(basics('basicsOptional').storageNewOrExisting, 'New'))]"
+					},
+					{
+						"name": "storageAccountType",
+						"type": "Microsoft.Common.DropDown",
+						"label": "Storage Account Type",
+                        "toolTip": "The data in your Azure storage account is always replicated to ensure durability and high availability. Choose a replication strategy that matches your durability requirements. Some settings can't be changed after the storage account is created.",
+						"defaultValue": "Standard_LRS",
+						"constraints": {
+							"allowedValues": [
+								{
+									"label": "Standard_LRS",
+									"value": "Standard_LRS"
+								},
+								{
+									"label": "Standard_GRS",
+									"value": "Standard_GRS"
+								}
+							],
+							"required": true
+						},
+						"visible": "[and(bool(basics('basicsOptional').basicsOptionalAcceptDefaults), equals(basics('basicsOptional').storageNewOrExisting, 'New'))]"
+					}
+                ],
+                "visible": true
             },
             {
                 "name": "howToReportIssues",
@@ -108,33 +320,93 @@
         ],
         "steps": [
             {
-                "name": "VirtualMachineConfig",
-                "label": "Virtual Machine Settings",
+                "name": "jbossEAPSettings",
+                "label": "JBoss EAP Settings",
                 "subLabel": {
-                    "preValidation": "Configure the virtual machine's resources and settings",
+                    "preValidation": "Provide the JBoss EAP admin Console settings",
                     "postValidation": "Done"
                 },
-                "bladeTitle": "Virtual Machine Settings",
+                "bladeTitle": "JBoss EAP Settings",
                 "elements": [
                     {
-                        "name": "vmSize",
-                        "type": "Microsoft.Compute.SizeSelector",
-                        "label": "Virtual machine size",
-                        "toolTip": "The size of virtual machine to provision",
-                        "recommendedSizes": [
-                            "Standard_DS2_v2",
-                            "Standard_DS3_v2",
-                            "Standard_DS4_v2",
-                            "Standard_E2S_v3",
-                            "Standard_E4S_v3",
-                            "Standard_E8S_v3",
-                            "Standard_F2S_v2",
-                            "Standard_F4S_v2",
-                            "Standard_F8S_v2" 
-                        ],
-                        "osPlatform": "Linux",
-                        "count": "1"
+                        "name": "jbossEAPUserName",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "JBoss EAP Admin username",
+                        "defaultValue": "jbossadmin",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-z0-9A-Z]{1,30}$",
+                            "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
+                        },
+                        "toolTip": "Provide User name for JBoss EAP Manager"
                     },
+                    {
+                        "name": "jbossEAPPassword",
+                        "type": "Microsoft.Common.PasswordBox",
+                        "label": {
+                            "password": "JBoss EAP password",
+                            "confirmPassword": "Confirm password"
+                        },
+                        "toolTip":"Provide Password for JBoss EAP Manager",
+                        "options": {
+                            "hideConfirmation": false
+                        },
+                        "constraints": {
+                            "required": true
+                        },
+                        "visible": true
+                    },
+                    {
+                        "name": "rhsmUserName",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
+                        "label": "RHSM username",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-zA-Z0-9+_.-]{1,30}(@[a-zA-Z0-9.-]+){0,1}$",
+                            "validationMessage": "Please enter a valid Red Hat Subscription Manager user id"
+                        },
+                        "toolTip": "Provide User name for Red Hat subscription Manager"
+                    },
+                    {
+                        "name": "rhsmPassword",
+                        "type": "Microsoft.Common.PasswordBox",
+                        "label": {
+                            "password": "RHSM password",
+                            "confirmPassword": "Confirm password"
+                        },
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
+                        "toolTip":"Provide Password for  Red Hat subscription Manager",
+                        "options": {
+                            "hideConfirmation": false
+                        },
+                        "constraints": {
+                            "required": true
+                        }
+                    },
+                    {
+                        "name": "rhsmPoolEAP",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
+                        "label": "RHSM Pool ID with EAP entitlement",
+                        "toolTip": "Red Hat Subscription Manager Pool ID (Should have EAP entitlement)",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-f0-9A-F]{32,32}$",
+                            "validationMessage": "The RHSM Pool ID must be 32 characters long and should contain only alphabets between a to f and numbers."
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "NetworkingConfig",
+                "label": "Networking",
+                "subLabel": {
+                    "preValidation": "Configure the virtual machine's networking settings",
+                    "postValidation": "Done"
+                },
+                "bladeTitle": "Networking",
+                "elements": [
                     {
                         "name": "vnetInfo",
                         "type": "Microsoft.Common.InfoBox",
@@ -155,17 +427,17 @@
                             "subnets": "Subnets for the virtual network"
                         },
                         "defaultValue": {
-                            "name": "VirtualNetwork",
+                            "name": "[concat('jboss-vnet', substring(guid(), 0, 6))]",
                             "addressPrefixSize": "/28"
                         },
                         "constraints": {
                             "minAddressPrefixSize": "/28"
                         },
                         "subnets": {
-                            "subnet1": {
-                                "label": "Subnet",
+                            "jbossSubnet": {
+                                "label": "Subnet for jboss",
                                 "defaultValue": {
-                                    "name": "Subnet-1",
+                                    "name": "jboss-subnet",
                                     "addressPrefixSize": "/29"
                                 },
                                 "constraints": {
@@ -175,144 +447,7 @@
                                 }
                             }
                         }
-                    },
-                    {
-                        "name": "bootDiagnostics",
-                        "type": "Microsoft.Common.OptionsGroup",
-                        "label": "Boot diagnostics",
-                        "defaultValue": "on",
-                        "toolTip": "Capture serial console outputs and screenshots of the virtual machine running on a host to help diagnose startup issues",
-                        "constraints": {
-                          "allowedValues": [
-                            {
-                              "label": "on",
-                              "value": "on"
-                            },
-                            {
-                              "label": "off",
-                              "value": "off"
-                            }
-                          ],
-                          "required": true
-                        },
-                        "visible": true
-                    },
-                    {
-						"name": "storageNewOrExisting",
-						"type": "Microsoft.Common.DropDown",
-						"label": "Storage Account",
-						"defaultValue": "New",
-						"toolTip": "Select new or existing Storage account",
-						"constraints": {
-							"allowedValues": [
-								{
-									"label": "Existing",
-									"value": "Existing"
-								},
-								{
-									"label": "New",
-									"value": "New"
-								}
-							],
-							"required": true
-						},
-						"visible": "[equals(steps('VirtualMachineConfig').bootDiagnostics, 'on')]"
-					},
-                    {
-                        "name": "armApiControl",
-                        "type": "Microsoft.Solutions.ArmApiControl",
-                        "request": {
-                          "method": "GET",
-                          "path": "[concat(subscription().id, '/providers/Microsoft.Storage/storageAccounts?api-version=2021-04-01')]"
-                        },
-                        "visible": "[equals(steps('VirtualMachineConfig').storageNewOrExisting, 'Existing')]"
-                      },
-                      {
-                        "name": "existingStorageAccount",
-                        "type": "Microsoft.Common.DropDown",
-                        "label": "Available storage accounts",
-                        "toolTip": "Select a storage account from the existing list",
-                        "constraints": {
-                          "allowedValues": "[filter(map(steps('VirtualMachineConfig').armApiControl.value, (item) => parse(concat('{\"label\":\"', concat(item.name,' (',item.kind,')'), '\",\"value\":\"', item.name, '\",\"kind\":\"', item.kind, '\",\"location\":\"', item.location, '\",\"tier\":\"', item.sku.tier, '\"}'))), (item) => and(and(not(contains(toLower(item.kind),'blob')),equals(location(),item.location)),equals('Standard',item.tier)))]",
-                          "required": true
-                        },
-                        "visible": "[equals(steps('VirtualMachineConfig').storageNewOrExisting, 'Existing')]"
-                    },
-					{
-                        "name": "nameApi",
-                        "type": "Microsoft.Solutions.ArmApiControl",
-                        "request": {
-                        "method": "POST",
-                        "path": "[concat(subscription().id,'/providers/Microsoft.Storage/checkNameAvailability?api-version=2019-06-01')]",
-                        "body":  {
-                            "name": "[steps('VirtualMachineConfig').storageAccountName.value]",
-                            "type": "Microsoft.Storage/storageAccounts"
-                            }
-                        },
-                        "visible": "[equals(steps('VirtualMachineConfig').storageNewOrExisting, 'New')]"
-                    },
-                    {
-                        "name": "storageAccountName",
-                        "type": "Microsoft.Common.TextBox",
-                        "label": "Storage Account Name",
-                        "toolTip": "Name of the storage account",
-                        "constraints": {
-                        "validations": [
-                            {
-                                "regex": "^[a-z0-9]{3,24}$",
-                                "message": "Storage account name should be between 3 and 24 characters and only contain lowercase letters and numbers"
-                            },
-                            {
-                                "isValid": "[not(equals(steps('VirtualMachineConfig').nameApi.nameAvailable, false))]",
-                                "message": "[concat('The storage account name \"',steps('VirtualMachineConfig').storageAccountName.value, '\" is unavailable or already taken')]"
-                            }
-                        ],
-                        "required": true
-                        },
-                        "visible": "[equals(steps('VirtualMachineConfig').storageNewOrExisting, 'New')]"
-                    },
-					{
-						"name": "storageAccountKind",
-						"type": "Microsoft.Common.DropDown",
-						"label": "Storage Account Kind",
-						"defaultValue": "Storage",
-						"toolTip": "General purpose storage accounts provide storage for blobs, files, tables, and queues in a unified account. Choose an access tier that matches your storage needs.",
-						"constraints": {
-							"allowedValues": [
-								{
-									"label": "Storage",
-									"value": "Storage"
-								},
-								{
-									"label": "StorageV2",
-									"value": "StorageV2"
-								}
-							],
-							"required": true
-						},
-						"visible": "[equals(steps('VirtualMachineConfig').storageNewOrExisting, 'New')]"
-					},
-					{
-						"name": "storageAccountType",
-						"type": "Microsoft.Common.DropDown",
-						"label": "Storage Account Type",
-                        "toolTip": "The data in your Azure storage account is always replicated to ensure durability and high availability. Choose a replication strategy that matches your durability requirements. Some settings can't be changed after the storage account is created.",
-						"defaultValue": "Standard_LRS",
-						"constraints": {
-							"allowedValues": [
-								{
-									"label": "Standard_LRS",
-									"value": "Standard_LRS"
-								},
-								{
-									"label": "Standard_GRS",
-									"value": "Standard_GRS"
-								}
-							],
-							"required": true
-						},
-						"visible": "[equals(steps('VirtualMachineConfig').storageNewOrExisting, 'New')]"
-					}
+                    }
                 ]
             },
             {
@@ -393,108 +528,31 @@
                         }
                     }
 				]
-            },
-            {
-                "name": "jbossEAPSettings",
-                "label": "JBoss EAP Settings",
-                "subLabel": {
-                    "preValidation": "Provide the JBoss EAP admin Console settings",
-                    "postValidation": "Done"
-                },
-                "bladeTitle": "JBoss EAP Settings",
-                "elements": [
-                    {
-                        "name": "jbossEAPUserName",
-                        "type": "Microsoft.Compute.UserNameTextBox",
-                        "label": "JBoss EAP Admin username",
-                        "osPlatform": "Linux",
-                        "constraints": {
-                            "required": true
-                        },
-                        "toolTip": "Provide User name for JBoss EAP Manager"
-                    },
-                    {
-                        "name": "jbossEAPPassword",
-                        "type": "Microsoft.Common.PasswordBox",
-                        "label": {
-                            "password": "JBoss EAP password",
-                            "confirmPassword": "Confirm password"
-                        },
-                        "toolTip":"Provide Password for JBoss EAP Manager",
-                        "options": {
-                            "hideConfirmation": false
-                        },
-                        "constraints": {
-                            "required": true
-                        },
-                        "visible": true
-                    },
-                    {
-                        "name": "rhsmUserName",
-                        "type": "Microsoft.Common.TextBox",
-                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
-                        "label": "RHSM username",
-                        "constraints": {
-                            "required": true,
-                            "regex": "^[a-zA-Z0-9+_.-]{1,30}(@[a-zA-Z0-9.-]+){0,1}$",
-                            "validationMessage": "Please enter a valid Red Hat Subscription Manager user id"
-                        },
-                        "toolTip": "Provide User name for Red Hat subscription Manager"
-                    },
-                    {
-                        "name": "rhsmPassword",
-                        "type": "Microsoft.Common.PasswordBox",
-                        "label": {
-                            "password": "RHSM password",
-                            "confirmPassword": "Confirm password"
-                        },
-                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
-                        "toolTip":"Provide Password for  Red Hat subscription Manager",
-                        "options": {
-                            "hideConfirmation": false
-                        },
-                        "constraints": {
-                            "required": true
-                        }
-                    },
-                    {
-                        "name": "rhsmPoolEAP",
-                        "type": "Microsoft.Common.TextBox",
-                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
-                        "label": "RHSM Pool ID with EAP entitlement",
-                        "toolTip": "Red Hat Subscription Manager Pool ID (Should have EAP entitlement)",
-                        "constraints": {
-                            "required": true,
-                            "regex": "^[a-f0-9A-F]{32,32}$",
-                            "validationMessage": "The RHSM Pool ID must be 32 characters long and should contain only alphabets between a to f and numbers."
-                        }
-                    }
-                ]
             }
         ],
         "outputs": {
 
             "location": "[location()]",
-            "vmName": "[basics('vmName')]",
+            "vmName": "[basics('basicsOptional').vmName]",
             "adminUsername": "[basics('adminUsername')]",
             "authenticationType": "[basics('authenticationType').authenticationType]",
             "adminPasswordOrSSHKey": "[coalesce(basics('authenticationType').password, basics('authenticationType').sshPublicKey)]",
+            "vmSize": "[basics('vmSize')]",
+            "jdkVersion": "[basics('jdkVersion')]",
+            "virtualNetworkNewOrExisting": "[steps('NetworkingConfig').virtualNetwork.newOrExisting]",
+            "virtualNetworkName": "[steps('NetworkingConfig').virtualNetwork.name]",
+            "addressPrefixes": "[steps('NetworkingConfig').virtualNetwork.addressPrefixes]",
+            "subnetName": "[steps('NetworkingConfig').virtualNetwork.subnets.jbossSubnet.name]",
+            "subnetPrefix": "[steps('NetworkingConfig').virtualNetwork.subnets.jbossSubnet.addressPrefix]",
+            "virtualNetworkResourceGroupName": "[steps('NetworkingConfig').virtualNetwork.resourceGroup]",
 
-            "vmSize": "[steps('VirtualMachineConfig').vmSize]",
-            "virtualNetworkNewOrExisting": "[steps('VirtualMachineConfig').virtualNetwork.newOrExisting]",
-            "virtualNetworkName": "[steps('VirtualMachineConfig').virtualNetwork.name]",
-            "addressPrefixes": "[steps('VirtualMachineConfig').virtualNetwork.addressPrefixes]",
-            "subnetName": "[steps('VirtualMachineConfig').virtualNetwork.subnets.subnet1.name]",
-            "subnetPrefix": "[steps('VirtualMachineConfig').virtualNetwork.subnets.subnet1.addressPrefix]",
-            "virtualNetworkResourceGroupName": "[steps('VirtualMachineConfig').virtualNetwork.resourceGroup]",
-
-            "bootDiagnostics": "[steps('VirtualMachineConfig').bootDiagnostics]",
-            "storageNewOrExisting": "[steps('VirtualMachineConfig').storageNewOrExisting]",
-            "existingStorageAccount": "[coalesce(steps('VirtualMachineConfig').existingStorageAccount,'')]",
-            "storageAccountName": "[steps('VirtualMachineConfig').storageAccountName.value]",
-            "storageAccountKind": "[steps('VirtualMachineConfig').storageAccountKind]",
-            "storageAccountType": "[steps('VirtualMachineConfig').storageAccountType]",
-            "storageAccountResourceGroupName": "[if(and(equals(steps('VirtualMachineConfig').bootDiagnostics, 'on'),not(empty(steps('VirtualMachineConfig').existingStorageAccount))), first(skip(split(coalesce(first(filter(steps('VirtualMachineConfig').armApiControl.value, (item) => equals(steps('VirtualMachineConfig').existingStorageAccount,item.name))),parse('{\"id\":\"/////\"}')).id, '/'),4)), resourceGroup().name)]",
+            "bootDiagnostics": "[basics('basicsOptional').bootDiagnostics]",
+            "storageNewOrExisting": "[basics('basicsOptional').storageNewOrExisting]",
+            "existingStorageAccount": "[coalesce(basics('basicsOptional').existingStorageAccount,'')]",
+            "storageAccountName": "[basics('basicsOptional').storageAccountName]",
+            "storageAccountKind": "[basics('basicsOptional').storageAccountKind]",
+            "storageAccountType": "[basics('basicsOptional').storageAccountType]",
+            "storageAccountResourceGroupName": "[if(and(equals(basics('basicsOptional').bootDiagnostics, 'on'),not(empty(basics('basicsOptional').existingStorageAccount))), first(skip(split(coalesce(first(filter(basics('basicsOptional').armApiControl.value, (item) => equals(basics('basicsOptional').existingStorageAccount,item.name))),parse('{\"id\":\"/////\"}')).id, '/'),4)), resourceGroup().name)]",
 
             "jbossEAPUserName": "[steps('jbossEAPSettings').jbossEAPUserName]",
             "jbossEAPPassword": "[steps('jbossEAPSettings').jbossEAPPassword]",

--- a/eap74-rhel8-payg/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-payg/src/main/bicep/mainTemplate.bicep
@@ -2,10 +2,10 @@
 param location string = resourceGroup().location
 
 @description('Name for the Virtual Machine.')
-param vmName string
+param vmName string = 'jbosseapVm'
 
 @description('Linux VM user account name')
-param adminUsername string
+param adminUsername string = 'jbossuser'
 
 @description('Type of authentication to use on the Virtual Machine')
 @allowed([
@@ -20,6 +20,9 @@ param adminPasswordOrSSHKey string
 
 @description('The size of the Virtual Machine')
 param vmSize string = 'Standard_B1ms'
+
+@description('The JDK version of the Virtual Machine')
+param jdkVersion string = 'openjdk17'
 
 @description('Capture serial console outputs and screenshots of the virtual machine running on a host to help diagnose startup issues')
 @allowed([
@@ -125,7 +128,7 @@ module partnerCenterPid './modules/_pids/_empty.bicep' = {
   params: {}
 }
 
-resource bootStorageName 'Microsoft.Storage/storageAccounts@2021-04-01' = if (bootDiagnosticsCheck) {
+resource bootStorageName 'Microsoft.Storage/storageAccounts@2022-05-01' = if (bootDiagnosticsCheck) {
   name: bootStorageName_var
   location: location
   sku: {
@@ -134,12 +137,12 @@ resource bootStorageName 'Microsoft.Storage/storageAccounts@2021-04-01' = if (bo
   kind: storageAccountKind
 }
 
-resource networkSecurityGroupName 'Microsoft.Network/networkSecurityGroups@2020-11-01' = {
+resource networkSecurityGroupName 'Microsoft.Network/networkSecurityGroups@2022-05-01' = {
   name: networkSecurityGroupName_var
   location: location
 }
 
-resource virtualNetworkName_resource 'Microsoft.Network/virtualNetworks@2020-11-01' = if (virtualNetworkNewOrExisting == 'new') {
+resource virtualNetworkName_resource 'Microsoft.Network/virtualNetworks@2022-05-01' = if (virtualNetworkNewOrExisting == 'new') {
   name: virtualNetworkName
   location: location
   properties: {
@@ -160,7 +163,7 @@ resource virtualNetworkName_resource 'Microsoft.Network/virtualNetworks@2020-11-
   }
 }
 
-resource nicName 'Microsoft.Network/networkInterfaces@2020-11-01' = {
+resource nicName 'Microsoft.Network/networkInterfaces@2022-05-01' = {
   name: nicName_var
   location: location
   properties: {
@@ -185,7 +188,7 @@ resource nicName 'Microsoft.Network/networkInterfaces@2020-11-01' = {
   ]
 }
 
-resource vmName_resource 'Microsoft.Compute/virtualMachines@2021-03-01' = {
+resource vmName_resource 'Microsoft.Compute/virtualMachines@2022-08-01' = {
   name: vmName
   location: location
   properties: {
@@ -202,7 +205,7 @@ resource vmName_resource 'Microsoft.Compute/virtualMachines@2021-03-01' = {
       imageReference: {
         publisher: 'RedHat'
         offer: 'RHEL'
-        sku: '8_4'
+        sku: '8_6'
         version: 'latest'
       }
       osDisk: {
@@ -227,7 +230,7 @@ resource vmName_resource 'Microsoft.Compute/virtualMachines@2021-03-01' = {
   ]
 }
 
-resource vmName_jbosseap_setup_extension 'Microsoft.Compute/virtualMachines/extensions@2021-03-01' = {
+resource vmName_jbosseap_setup_extension 'Microsoft.Compute/virtualMachines/extensions@2022-08-01' = {
   parent: vmName_resource
   name: 'jbosseap-setup-extension'
   location: location
@@ -242,7 +245,7 @@ resource vmName_jbosseap_setup_extension 'Microsoft.Compute/virtualMachines/exte
       ]
     }
     protectedSettings: {
-      commandToExecute: 'sh jbosseap-setup-redhat.sh \'${jbossEAPUserName}\' \'${base64(jbossEAPPassword)}\' \'${rhsmUserName}\' \'${base64(rhsmPassword)}\' \'${rhsmPoolEAP}\' \'${connectSatellite}\' \'${base64(satelliteActivationKey)}\' \'${base64(satelliteOrgName)}\' \'${satelliteFqdn}\''
+      commandToExecute: 'sh jbosseap-setup-redhat.sh \'${jbossEAPUserName}\' \'${base64(jbossEAPPassword)}\' \'${rhsmUserName}\' \'${base64(rhsmPassword)}\' \'${rhsmPoolEAP}\' \'${connectSatellite}\' \'${base64(satelliteActivationKey)}\' \'${base64(satelliteOrgName)}\' \'${satelliteFqdn}\' \'${jdkVersion}\''
     }
   }
 }

--- a/eap74-rhel8-payg/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-payg/src/main/scripts/jbosseap-setup-redhat.sh
@@ -25,6 +25,7 @@ SATELLITE_ACTIVATION_KEY=$(echo $SATELLITE_ACTIVATION_KEY_BASE64 | base64 -d)
 SATELLITE_ORG_NAME_BASE64=${8}
 SATELLITE_ORG_NAME=$(echo $SATELLITE_ORG_NAME_BASE64 | base64 -d)
 SATELLITE_VM_FQDN=${9}
+JDK_VERSION=${10}
 NODE_ID=$(uuidgen | sed 's/-//g' | cut -c 1-23)
 
 export EAP_HOME="/opt/rh/eap7/root/usr/share/wildfly"
@@ -63,6 +64,22 @@ else
     if [ $flag != 0 ] ; then echo  "ERROR! Pool Attach for JBoss EAP Failed" >&2 log; exit $flag;  fi
 fi
 
+####################### Install openjdk, EAP 7.4 is shipped with JDK 1.8, we are allowing more
+echo "Install openjdk, curl, wget, git, unzip, vim" | log; flag=${PIPESTATUS[0]}
+echo "sudo yum install curl wget unzip vim git -y" | log; flag=${PIPESTATUS[0]}
+sudo yum install curl wget unzip vim git -y | log; flag=${PIPESTATUS[0]}
+## Install specific JDK version
+if [[ "${JDK_VERSION,,}" == "openjdk17" ]]; then
+    echo "sudo yum install java-17-openjdk -y" | log; flag=${PIPESTATUS[0]}
+    sudo yum install java-17-openjdk -y | log; flag=${PIPESTATUS[0]}
+elif [[ "${JDK_VERSION,,}" == "openjdk11" ]]; then
+    echo "sudo yum install java-11-openjdk -y" | log; flag=${PIPESTATUS[0]}
+    sudo yum install java-11-openjdk -y | log; flag=${PIPESTATUS[0]}
+elif [[ "${JDK_VERSION,,}" == "openjdk8" ]]; then
+    echo "openjdk8 is shipped with EAP 7.4, proceed" | log; flag=${PIPESTATUS[0]}
+fi
+####################### 
+
 # Install JBoss EAP 7.4
 echo "subscription-manager repos --enable=jb-eap-7.4-for-rhel-8-x86_64-rpms" | log; flag=${PIPESTATUS[0]}
 subscription-manager repos --enable=jb-eap-7.4-for-rhel-8-x86_64-rpms | log; flag=${PIPESTATUS[0]}
@@ -73,19 +90,24 @@ echo "yum groupinstall -y jboss-eap7" | log; flag=${PIPESTATUS[0]}
 yum groupinstall -y jboss-eap7 | log; flag=${PIPESTATUS[0]}
 if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP installation Failed" >&2 log; exit $flag;  fi
 
-echo "Updating standalone.xml" | log; flag=${PIPESTATUS[0]}
+echo "Updating standalone-full-ha.xml" | log; flag=${PIPESTATUS[0]}
 echo -e "\t stack UDP to TCP"  | log; flag=${PIPESTATUS[0]}
 echo -e "\t set transaction id"     | log; flag=${PIPESTATUS[0]}
 
+## OpenJDK 17 specific logic
+if [[ "${JDK_VERSION,,}" == "openjdk17" ]]; then
+    sudo -u jboss $EAP_HOME/bin/jboss-cli.sh --file=$EAP_HOME/docs/examples/enable-elytron-se17.cli -Dconfig=standalone-full-ha.xml
+fi
+
 sudo -u jboss $EAP_HOME/bin/jboss-cli.sh --echo-command \
-'embed-server --std-out=echo  --server-config=standalone.xml',\
+'embed-server --std-out=echo  --server-config=standalone-full-ha.xml',\
 '/subsystem=transactions:write-attribute(name=node-identifier,value="'${NODE_ID}'")',\
 '/subsystem=jgroups/channel=ee:write-attribute(name="stack", value="tcp")' | log; flag=${PIPESTATUS[0]}
 
 ####################### Configure the JBoss server and setup eap service
 echo "Setting configurations in $EAP_RPM_CONF_STANDALONE"
-echo -e "\t-> WILDFLY_SERVER_CONFIG=standalone.xml" | log; flag=${PIPESTATUS[0]}
-echo 'WILDFLY_SERVER_CONFIG=standalone.xml' >> $EAP_RPM_CONF_STANDALONE | log; flag=${PIPESTATUS[0]}
+echo -e "\t-> WILDFLY_SERVER_CONFIG=standalone-full-ha.xml" | log; flag=${PIPESTATUS[0]}
+echo 'WILDFLY_SERVER_CONFIG=standalone-full-ha.xml' >> $EAP_RPM_CONF_STANDALONE | log; flag=${PIPESTATUS[0]}
 
 echo "Setting configurations in $EAP_LAUNCH_CONFIG"
 echo -e '\t-> JAVA_OPTS=$JAVA_OPTS -Djboss.bind.address=0.0.0.0' | log; flag=${PIPESTATUS[0]}


### PR DESCRIPTION
## Change
* Support configurable OpenJDK versions (8, 11, 17)
* Update pipeline to avoid arm-ttk failures
* Reorg UX for usability improvments

## Test
* Pipeline
    * [Build PAYG single artifact](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/3467606360)
    * [Validate payg offer](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/3467626472)
* Preview offer
    * Tested with OpenJDK 17, boot diagnostics enabled and existing VNET

Signed-off-by: Zheng Chang <zhengchang@microsoft.com>