### PR TITLE
Support configurable OpenJDK versions in PAYG VMSS offer

### DIFF
--- a/.github/workflows/build-artifact-payg-vmss.yaml
+++ b/.github/workflows/build-artifact-payg-vmss.yaml
@@ -13,8 +13,6 @@ on:
   # curl --verbose -X POST https://api.github.com/repos/<github_user>/rhel-jboss-templates/dispatches -H 'Accept: application/vnd.github.everest-preview+json' -H 'Authorization: token <personal_access_token>' --data '{"event_type": "byos-vmss-package", "client_payload": {"ref": "refs/heads/main"}}'
 
 env:
-    refArmttk: bad2965565e2e69318039bc15c2496844d55a59d
-    refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
     azCliVersion: 2.30.0
     location: eastus
     offerName: "eap74-rhel8-payg-vmss"
@@ -25,6 +23,14 @@ jobs:
     preflight:
         runs-on: ubuntu-latest
         steps:
+            - name: Get versions of external dependencies
+              run: |
+                curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
+                source external-deps-versions.properties
+                echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
+                echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
+                echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
+                echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
             - name: Setup environment variables
               id: setup-env-variables-based-on-dispatch-event
               run: |
@@ -38,10 +44,11 @@ jobs:
                 fi
                 echo "##[set-output name=ref;]${ref}"
                 echo "ref=${ref}" >> $GITHUB_ENV
-            - name: Set up JDK 1.8
-              uses: actions/setup-java@v1
+            - name: Set up JDK 11
+              uses: actions/setup-java@v3
               with:
-                java-version: 1.8
+                distribution: 'temurin'
+                java-version: '11'
             - name: Set up bicep
               run: |
                 curl -Lo bicep https://github.com/Azure/bicep/releases/download/v0.8.9/bicep-linux-x64
@@ -49,13 +56,13 @@ jobs:
                 sudo mv ./bicep /usr/local/bin/bicep
                 bicep --version
             - name: Checkout azure-javaee-iaas
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: Azure/azure-javaee-iaas
                 path: azure-javaee-iaas
                 ref: ${{ env.refJavaee }}
             - name: Checkout arm-ttk
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: Azure/arm-ttk
                 path: arm-ttk
@@ -63,7 +70,7 @@ jobs:
             - name: Build azure-javaee-iaas
               run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
             - name: Checkout ${{ env.repoName }}
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 path: ${{ env.repoName }}
                 ref: ${{ env.ref }}

--- a/.github/workflows/validate-payg-vmss.yaml
+++ b/.github/workflows/validate-payg-vmss.yaml
@@ -10,8 +10,6 @@ on:
 
 env:
     azCliVersion: 2.30.0
-    refArmttk: bad2965565e2e69318039bc15c2496844d55a59d
-    refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
     location: eastus
     vmssResourceGroup: vmss-${{ github.run_id }}-${{ github.run_number }}
@@ -41,24 +39,33 @@ jobs:
           isForDemo: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.isForDemo }}
         runs-on: ubuntu-latest
         steps:
-            - name: Set up JDK 1.8
-              uses: actions/setup-java@v1
+            - name: Get versions of external dependencies
+              run: |
+                curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
+                source external-deps-versions.properties
+                echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
+                echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
+                echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
+                echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
+            - name: Set up JDK 11
+              uses: actions/setup-java@v3
               with:
-                java-version: 1.8
+                distribution: 'temurin'
+                java-version: '11'
             - name: Set up bicep
               run: |
-                curl -Lo bicep https://github.com/Azure/bicep/releases/download/v0.4.613/bicep-linux-x64
+                curl -Lo bicep https://github.com/Azure/bicep/releases/download/${{ env.bicepVersion }}/bicep-linux-x64
                 chmod +x ./bicep
                 sudo mv ./bicep /usr/local/bin/bicep
                 bicep --version
             - name: Checkout azure-javaee-iaas
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: Azure/azure-javaee-iaas
                 path: azure-javaee-iaas
                 ref: ${{ env.refJavaee }}
             - name: Checkout arm-ttk
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: Azure/arm-ttk
                 path: arm-ttk
@@ -66,7 +73,7 @@ jobs:
             - name: Build azure-javaee-iaas
               run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
             - name: Checkout rhel-jboss-templates
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: ${{env.gitUserName}}/rhel-jboss-templates
                 path: rhel-jboss-templates
@@ -100,7 +107,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout rhel-jboss-templates
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: ${{env.gitUserName}}/rhel-jboss-templates
                 path: rhel-jboss-templates
@@ -257,7 +264,7 @@ jobs:
                   echo "delete... " $vmssResourceGroup
                   az group delete --yes --no-wait --verbose --name $vmssResourceGroup
             - name: Checkout rhel-jboss-templates
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: ${{env.gitUserName}}/rhel-jboss-templates
                 path: rhel-jboss-templates

--- a/eap74-rhel8-payg-vmss/pom.xml
+++ b/eap74-rhel8-payg-vmss/pom.xml
@@ -5,12 +5,12 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-payg-vmss</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.16</version>
+        <version>1.0.18</version>
         <relativePath></relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/eap74-rhel8-payg-vmss/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-vmss/src/main/arm/createUiDefinition.json
@@ -5,22 +5,55 @@
     "parameters": {
         "basics": [
             {
-                "name": "vmssName",
-                "type": "Microsoft.Common.TextBox",
-                "label": "Virtual Machine Scale Set name",
-                "toolTip": "The name of the Virtual Machine Scale Set",
+                "name": "vmSize",
+                "type": "Microsoft.Compute.SizeSelector",
+                "label": "Virtual machine size",
+                "toolTip": "The size of virtual machine to provision",
+                "recommendedSizes": [
+                    "Standard_DS2_v2",
+                    "Standard_DS3_v2",
+                    "Standard_DS4_v2",
+                    "Standard_E2S_v3",
+                    "Standard_E4S_v3",
+                    "Standard_E8S_v3",
+                    "Standard_F2S_v2",
+                    "Standard_F4S_v2",
+                    "Standard_F8S_v2" 
+                ],
+                "osPlatform": "Linux",
+                "count": "1"
+            },
+            {
+                "name": "jdkVersion",
+                "type": "Microsoft.Common.DropDown",
+                "label": "JDK version",
+                "defaultValue": "OpenJDK 17",
+                "toolTip": "Choose JDK version.",
                 "constraints": {
-                    "required": true,
-                    "regex": "^[a-z0-9A-Z-]{3,9}$",
-                    "validationMessage": "The Virtual Machine Scale Set Name must be between 3 and 9 characters long and contain letters, numbers and hyphens only."
-                }
+                    "allowedValues": [
+                        {
+                            "label": "OpenJDK 8",
+                            "value": "openjdk8"
+                        },
+                        {
+                            "label": "OpenJDK 11",
+                            "value": "openjdk11"
+                        },
+                        {
+                            "label": "OpenJDK 17",
+                            "value": "openjdk17"
+                        }
+                    ],
+                    "required": true
+                },
+                "visible": true
             },
             {
                 "name": "adminUsername",
-                "type": "Microsoft.Compute.UserNameTextBox",
+                "type": "Microsoft.Common.TextBox",
                 "label": "Username",
+                "defaultValue": "jbossuser",
                 "toolTip": "Linux VM user account name",
-                "osPlatform": "Linux",
                 "constraints": {
                     "required": true,
                     "regex": "^[a-zA-Z]+[a-zA-Z0-9_-]{1,64}$",
@@ -48,6 +81,203 @@
                     "hideConfirmation": false
                 },
                 "osPlatform": "Linux"
+            },
+            {
+                "name": "numberOfInstances",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Number of Instances",
+                "defaultValue": "2",
+                "toolTip": "Number of VMs in Scale Set",
+                "placeholder": "2",
+                "constraints": {
+                    "required": true,
+                    "validations": [
+                        {
+                            "regex": "^100$|^[2-9]$|^[1-9][0-9]{1,1}$",
+                            "message": "Only numbers from 2 to 100 are allowed."
+                        }
+                    ]
+                },
+                "visible": true
+            },
+            {
+                "name": "basicsOptional",
+                "type": "Microsoft.Common.Section",
+                "label": "Optional Basic Configuration",
+                "elements": [
+                    {
+                        "name": "basicsOptionalAcceptDefaults",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Accept defaults for optional configuration?",
+                        "defaultValue": "Yes",
+                        "toolTip": "Select 'No' to edit optional basic configuration.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": "false"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "true"
+                                }
+                            ],
+                            "required": true
+                        }
+                    },
+                    {
+                        "name": "vmssName",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "Virtual Machine Scale Set name",
+                        "defaultValue": "jbossvmss",
+                        "toolTip": "The name of the Virtual Machine Scale Set",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-z0-9A-Z-]{3,9}$",
+                            "validationMessage": "The Virtual Machine Scale Set Name must be between 3 and 9 characters long and contain letters, numbers and hyphens only."
+                        },
+                        "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
+                    },
+                    {
+                        "name": "bootDiagnostics",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Boot diagnostics",
+                        "defaultValue": "off",
+                        "toolTip": "Capture serial console outputs and screenshots of the virtual machine running on a host to help diagnose startup issues",
+                        "constraints": {
+                          "allowedValues": [
+                            {
+                              "label": "on",
+                              "value": "on"
+                            },
+                            {
+                              "label": "off",
+                              "value": "off"
+                            }
+                          ],
+                          "required": true
+                        },
+                        "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
+                    },
+                    {
+						"name": "storageNewOrExisting",
+						"type": "Microsoft.Common.DropDown",
+						"label": "Storage Account",
+						"defaultValue": "New",
+						"toolTip": "Select new or existing Storage account",
+						"constraints": {
+							"allowedValues": [
+								{
+									"label": "Existing",
+									"value": "Existing"
+								},
+								{
+									"label": "New",
+									"value": "New"
+								}
+							],
+							"required": true
+						},
+						"visible": "[and(bool(basics('basicsOptional').basicsOptionalAcceptDefaults), equals(basics('basicsOptional').bootDiagnostics, 'on'))]"
+					},
+                    {
+                        "name": "armApiControl",
+                        "type": "Microsoft.Solutions.ArmApiControl",
+                        "request": {
+                          "method": "GET",
+                          "path": "[concat(subscription().id, '/providers/Microsoft.Storage/storageAccounts?api-version=2021-04-01')]"
+                        },
+                        "visible": "[and(bool(basics('basicsOptional').basicsOptionalAcceptDefaults), equals(basics('basicsOptional').storageNewOrExisting, 'Existing'))]"
+                      },
+                      {
+                        "name": "existingStorageAccount",
+                        "type": "Microsoft.Common.DropDown",
+                        "label": "Available storage accounts",
+                        "toolTip": "Select a storage account from the existing list",
+                        "constraints": {
+                          "allowedValues": "[filter(map(basics('basicsOptional').armApiControl.value, (item) => parse(concat('{\"label\":\"', concat(item.name,' (',item.kind,')'), '\",\"value\":\"', item.name, '\",\"kind\":\"', item.kind, '\",\"location\":\"', item.location, '\",\"tier\":\"', item.sku.tier, '\"}'))), (item) => and(and(not(contains(toLower(item.kind),'blob')),equals(location(),item.location)),equals('Standard',item.tier)))]",
+                          "required": true
+                        },
+                        "visible": "[and(bool(basics('basicsOptional').basicsOptionalAcceptDefaults), equals(basics('basicsOptional').storageNewOrExisting, 'Existing'))]"
+                    },
+					{
+                        "name": "nameApi",
+                        "type": "Microsoft.Solutions.ArmApiControl",
+                        "request": {
+                        "method": "POST",
+                        "path": "[concat(subscription().id,'/providers/Microsoft.Storage/checkNameAvailability?api-version=2019-06-01')]",
+                        "body":  {
+                            "name": "[basics('basicsOptional').storageAccountName]",
+                            "type": "Microsoft.Storage/storageAccounts"
+                            }
+                        },
+                        "visible": "[and(bool(basics('basicsOptional').basicsOptionalAcceptDefaults), equals(basics('basicsOptionalAcceptDefaults').storageNewOrExisting, 'New'))]"
+                    },
+                    {
+                        "name": "storageAccountName",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "Storage Account Name",
+                        "defaultValue": "[concat('jbosssa', substring(guid(), 0, 6))]",
+                        "toolTip": "Name of the storage account",
+                        "constraints": {
+                        "validations": [
+                            {
+                                "regex": "^[a-z0-9]{3,24}$",
+                                "message": "Storage account name should be between 3 and 24 characters and only contain lowercase letters and numbers"
+                            },
+                            {
+                                "isValid": "[not(equals(basics('basicsOptional').nameApi.nameAvailable, false))]",
+                                "message": "[concat('The storage account name \"',basics('basicsOptional').storageAccountName, '\" is unavailable or already taken')]"
+                            }
+                        ],
+                        "required": true
+                        },
+                        "visible": "[and(bool(basics('basicsOptional').basicsOptionalAcceptDefaults), equals(basics('basicsOptional').storageNewOrExisting, 'New'))]"
+                    },
+					{
+						"name": "storageAccountKind",
+						"type": "Microsoft.Common.DropDown",
+						"label": "Storage Account Kind",
+						"defaultValue": "Storage",
+						"toolTip": "General purpose storage accounts provide storage for blobs, files, tables, and queues in a unified account. Choose an access tier that matches your storage needs.",
+						"constraints": {
+							"allowedValues": [
+								{
+									"label": "Storage",
+									"value": "Storage"
+								},
+								{
+									"label": "StorageV2",
+									"value": "StorageV2"
+								}
+							],
+							"required": true
+						},
+						"visible": "[and(bool(basics('basicsOptional').basicsOptionalAcceptDefaults), equals(basics('basicsOptional').storageNewOrExisting, 'New'))]"
+					},
+					{
+						"name": "storageAccountType",
+						"type": "Microsoft.Common.DropDown",
+						"label": "Storage Account Type",
+                        "toolTip": "The data in your Azure storage account is always replicated to ensure durability and high availability. Choose a replication strategy that matches your durability requirements. Some settings can't be changed after the storage account is created.",
+						"defaultValue": "Standard_LRS",
+						"constraints": {
+							"allowedValues": [
+								{
+									"label": "Standard_LRS",
+									"value": "Standard_LRS"
+								},
+								{
+									"label": "Standard_GRS",
+									"value": "Standard_GRS"
+								}
+							],
+							"required": true
+						},
+						"visible": "[and(bool(basics('basicsOptional').basicsOptionalAcceptDefaults), equals(basics('basicsOptional').storageNewOrExisting, 'New'))]"
+					}
+                ],
+                "visible": true
             },
             {
                 "name": "howToReportIssues",
@@ -107,52 +337,95 @@
             }
         ],
         "steps": [
+            
             {
-                "name": "VirtualMachineConfig",
-                "label": "Virtual Machine Settings",
+                "name": "jbossEAPSettings",
+                "label": "JBoss EAP Settings",
                 "subLabel": {
-                    "preValidation": "Configure the virtual machine's resources and settings",
+                    "preValidation": "Provide the JBoss EAP admin Console settings",
                     "postValidation": "Done"
                 },
-                "bladeTitle": "Virtual Machine Settings",
+                "bladeTitle": "JBoss EAP Settings",
                 "elements": [
                     {
-                        "name": "numberOfInstances",
+                        "name": "jbossEAPUserName",
                         "type": "Microsoft.Common.TextBox",
-                        "label": "Number of Instances",
-                        "defaultValue": "2",
-                        "toolTip": "Use only allowed characters",
-                        "placeholder": "2",
+                        "label": "JBoss EAP Admin username",
+                        "defaultValue": "jbossadmin",
                         "constraints": {
                             "required": true,
-                            "validations": [
-                                {
-                                    "regex": "^100$|^[2-9]$|^[1-9][0-9]{1,1}$",
-                                    "message": "Only numbers from 2 to 100 are allowed."
-                                }
-                            ]
+                            "regex": "^[a-z0-9A-Z]{1,30}$",
+                            "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
+                        },
+                        "toolTip": "Provide User name for JBoss EAP Manager"
+                    },
+                    {
+                        "name": "jbossEAPPassword",
+                        "type": "Microsoft.Common.PasswordBox",
+                        "label": {
+                            "password": "JBoss EAP password",
+                            "confirmPassword": "Confirm password"
+                        },
+                        "toolTip": "Provide Password for JBoss EAP Manager",
+                        "options": {
+                            "hideConfirmation": false
+                        },
+                        "constraints": {
+                            "required": true
                         },
                         "visible": true
                     },
                     {
-                        "name": "vmSize",
-                        "type": "Microsoft.Compute.SizeSelector",
-                        "label": "Virtual machine size",
-                        "toolTip": "The size of virtual machine to provision",
-                        "recommendedSizes": [
-                            "Standard_DS2_v2",
-                            "Standard_DS3_v2",
-                            "Standard_DS4_v2",
-                            "Standard_E2S_v3",
-                            "Standard_E4S_v3",
-                            "Standard_E8S_v3",
-                            "Standard_F2S_v2",
-                            "Standard_F4S_v2",
-                            "Standard_F8S_v2"
-                        ],
-                        "osPlatform": "Linux",
-                        "count": "1"
+                        "name": "rhsmUserName",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
+                        "label": "RHSM username",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-zA-Z0-9+_.-]{1,30}(@[a-zA-Z0-9.-]+){0,1}$",
+                            "validationMessage": "Please enter a valid Red Hat Subscription Manager user id"
+                        },
+                        "toolTip": "Provide User name for Red Hat subscription Manager"
                     },
+                    {
+                        "name": "rhsmPassword",
+                        "type": "Microsoft.Common.PasswordBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
+                        "label": {
+                            "password": "RHSM password",
+                            "confirmPassword": "Confirm password"
+                        },
+                        "toolTip": "Provide Password for  Red Hat subscription Manager",
+                        "options": {
+                            "hideConfirmation": false
+                        },
+                        "constraints": {
+                            "required": true
+                        }
+                    },
+                    {
+                        "name": "rhsmPoolEAP",
+                        "type": "Microsoft.Common.TextBox",
+                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
+                        "label": "RHSM Pool ID with EAP entitlement",
+                        "toolTip": "Red Hat Subscription Manager Pool ID (Should have EAP entitlement)",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-f0-9A-F]{32,32}$",
+                            "validationMessage": "The RHSM Pool ID must be 32 characters long and should contain only alphabets between a to f and numbers."
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "NetworkingConfig",
+                "label": "Networking",
+                "subLabel": {
+                    "preValidation": "Configure the virtual machine's networking settings",
+                    "postValidation": "Done"
+                },
+                "bladeTitle": "Networking",
+                "elements": [
                     {
                         "name": "vnetInfo",
                         "type": "Microsoft.Common.InfoBox",
@@ -173,164 +446,27 @@
                             "subnets": "Subnets for the virtual network"
                         },
                         "defaultValue": {
-                            "name": "VirtualNetwork",
+                            "name": "[concat('jboss-vnet', substring(guid(), 0, 6))]",
                             "addressPrefixSize": "/28"
                         },
                         "constraints": {
                             "minAddressPrefixSize": "/28"
                         },
                         "subnets": {
-                            "subnet1": {
-                                "label": "Subnet",
+                            "jbossSubnet": {
+                                "label": "Subnet for jboss",
                                 "defaultValue": {
-                                    "name": "Subnet-1",
+                                    "name": "jboss-subnet",
                                     "addressPrefixSize": "/28"
                                 },
                                 "constraints": {
                                     "minAddressPrefixSize": "/29",
-                                    "minAddressCount": "[add(int(steps('VirtualMachineConfig').numberOfInstances), 1)]",
+                                    "minAddressCount": "[add(int(basics('numberOfInstances')), 1)]",
                                     "requireContiguousAddresses": false
                                 }
                             }
                         }
-                    },
-                    {
-                        "name": "bootDiagnostics",
-                        "type": "Microsoft.Common.OptionsGroup",
-                        "label": "Boot diagnostics",
-                        "defaultValue": "on",
-                        "toolTip": "Capture serial console outputs and screenshots of the virtual machine running on a host to help diagnose startup issues",
-                        "constraints": {
-                            "allowedValues": [
-                                {
-                                    "label": "on",
-                                    "value": "on"
-                                },
-                                {
-                                    "label": "off",
-                                    "value": "off"
-                                }
-                            ],
-                            "required": true
-                        },
-                        "visible": true
-                    },
-                    {
-						"name": "storageNewOrExisting",
-						"type": "Microsoft.Common.DropDown",
-						"label": "Storage Account",
-						"defaultValue": "New",
-						"toolTip": "Select new or existing Storage account",
-						"constraints": {
-							"allowedValues": [
-								{
-									"label": "Existing",
-									"value": "Existing"
-								},
-								{
-									"label": "New",
-									"value": "New"
-								}
-							],
-							"required": true
-						},
-						"visible": "[equals(steps('VirtualMachineConfig').bootDiagnostics, 'on')]"
-					},
-                    {
-                        "name": "armApiControl",
-                        "type": "Microsoft.Solutions.ArmApiControl",
-                        "request": {
-                          "method": "GET",
-                          "path": "[concat(subscription().id, '/providers/Microsoft.Storage/storageAccounts?api-version=2021-04-01')]"
-                        },
-                        "visible": "[equals(steps('VirtualMachineConfig').storageNewOrExisting, 'Existing')]"
-                      },
-                      {
-                        "name": "existingStorageAccount",
-                        "type": "Microsoft.Common.DropDown",
-                        "label": "Available storage accounts",
-                        "toolTip": "Select a storage account from the existing list",
-                        "constraints": {
-                          "allowedValues": "[filter(map(steps('VirtualMachineConfig').armApiControl.value, (item) => parse(concat('{\"label\":\"', concat(item.name,' (',item.kind,')'), '\",\"value\":\"', item.name, '\",\"kind\":\"', item.kind, '\",\"location\":\"', item.location, '\",\"tier\":\"', item.sku.tier, '\"}'))), (item) => and(and(not(contains(toLower(item.kind),'blob')),equals(location(),item.location)),equals('Standard',item.tier)))]",
-                          "required": true
-                        },
-                        "visible": "[equals(steps('VirtualMachineConfig').storageNewOrExisting, 'Existing')]"
-                    },
-					{
-                        "name": "nameApi",
-                        "type": "Microsoft.Solutions.ArmApiControl",
-                        "request": {
-                        "method": "POST",
-                        "path": "[concat(subscription().id,'/providers/Microsoft.Storage/checkNameAvailability?api-version=2019-06-01')]",
-                        "body":  {
-                            "name": "[steps('VirtualMachineConfig').storageAccountName.value]",
-                            "type": "Microsoft.Storage/storageAccounts"
-                            }
-                        },
-                        "visible": "[equals(steps('VirtualMachineConfig').storageNewOrExisting, 'New')]"
-                    },
-                    {
-                        "name": "storageAccountName",
-                        "type": "Microsoft.Common.TextBox",
-                        "label": "Storage Account Name",
-                        "toolTip": "Name of the storage account",
-                        "constraints": {
-                        "validations": [
-                            {
-                                "regex": "^[a-z0-9]{3,24}$",
-                                "message": "Storage account name should be between 3 and 24 characters and only contain lowercase letters and numbers"
-                            },
-                            {
-                                "isValid": "[not(equals(steps('VirtualMachineConfig').nameApi.nameAvailable, false))]",
-                                "message": "[concat('The storage account name \"',steps('VirtualMachineConfig').storageAccountName.value, '\" is unavailable or already taken')]"
-                            }
-                        ],
-                        "required": true
-                        },
-                        "visible": "[equals(steps('VirtualMachineConfig').storageNewOrExisting, 'New')]"
-                    },
-					{
-						"name": "storageAccountKind",
-						"type": "Microsoft.Common.DropDown",
-						"label": "Storage Account Kind",
-						"defaultValue": "Storage",
-						"toolTip": "General purpose storage accounts provide storage for blobs, files, tables, and queues in a unified account. Choose an access tier that matches your storage needs.",
-						"constraints": {
-							"allowedValues": [
-								{
-									"label": "Storage",
-									"value": "Storage"
-								},
-								{
-									"label": "StorageV2",
-									"value": "StorageV2"
-								}
-							],
-							"required": true
-						},
-						"visible": "[equals(steps('VirtualMachineConfig').storageNewOrExisting, 'New')]"
-					},
-					{
-						"name": "storageAccountType",
-						"type": "Microsoft.Common.DropDown",
-						"label": "Storage Account Type",
-                        "toolTip": "The data in your Azure storage account is always replicated to ensure durability and high availability. Choose a replication strategy that matches your durability requirements. Some settings can't be changed after the storage account is created.",
-						"defaultValue": "Standard_LRS",
-						"constraints": {
-							"allowedValues": [
-								{
-									"label": "Standard_LRS",
-									"value": "Standard_LRS"
-								},
-								{
-									"label": "Standard_GRS",
-									"value": "Standard_GRS"
-								}
-							],
-							"required": true
-						},
-						"visible": "[equals(steps('VirtualMachineConfig').storageNewOrExisting, 'New')]"
-					}
+                    }
                 ]
             },
             {
@@ -411,110 +547,33 @@
                         }
                     }
 				]
-            },
-            {
-                "name": "jbossEAPSettings",
-                "label": "JBoss EAP Settings",
-                "subLabel": {
-                    "preValidation": "Provide the JBoss EAP admin Console settings",
-                    "postValidation": "Done"
-                },
-                "bladeTitle": "JBoss EAP Settings",
-                "elements": [
-                    {
-                        "name": "jbossEAPUserName",
-                        "type": "Microsoft.Compute.UserNameTextBox",
-                        "label": "JBoss EAP Admin username",
-                        "osPlatform": "Linux",
-                        "constraints": {
-                            "required": true
-                        },
-                        "toolTip": "Provide User name for JBoss EAP Manager"
-                    },
-                    {
-                        "name": "jbossEAPPassword",
-                        "type": "Microsoft.Common.PasswordBox",
-                        "label": {
-                            "password": "JBoss EAP password",
-                            "confirmPassword": "Confirm password"
-                        },
-                        "toolTip": "Provide Password for JBoss EAP Manager",
-                        "options": {
-                            "hideConfirmation": false
-                        },
-                        "constraints": {
-                            "required": true
-                        },
-                        "visible": true
-                    },
-                    {
-                        "name": "rhsmUserName",
-                        "type": "Microsoft.Common.TextBox",
-                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
-                        "label": "RHSM username",
-                        "constraints": {
-                            "required": true,
-                            "regex": "^[a-zA-Z0-9+_.-]{1,30}(@[a-zA-Z0-9.-]+){0,1}$",
-                            "validationMessage": "Please enter a valid Red Hat Subscription Manager user id"
-                        },
-                        "toolTip": "Provide User name for Red Hat subscription Manager"
-                    },
-                    {
-                        "name": "rhsmPassword",
-                        "type": "Microsoft.Common.PasswordBox",
-                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
-                        "label": {
-                            "password": "RHSM password",
-                            "confirmPassword": "Confirm password"
-                        },
-                        "toolTip": "Provide Password for  Red Hat subscription Manager",
-                        "options": {
-                            "hideConfirmation": false
-                        },
-                        "constraints": {
-                            "required": true
-                        }
-                    },
-                    {
-                        "name": "rhsmPoolEAP",
-                        "type": "Microsoft.Common.TextBox",
-                        "visible": "[not(steps('satelliteServerSettings').connectSatellite)]",
-                        "label": "RHSM Pool ID with EAP entitlement",
-                        "toolTip": "Red Hat Subscription Manager Pool ID (Should have EAP entitlement)",
-                        "constraints": {
-                            "required": true,
-                            "regex": "^[a-f0-9A-F]{32,32}$",
-                            "validationMessage": "The RHSM Pool ID must be 32 characters long and should contain only alphabets between a to f and numbers."
-                        }
-                    }
-                ]
             }
         ],
         "outputs": {
             "location": "[location()]",
-            "vmssName": "[basics('vmssName')]",
+            "vmssName": "[basics('basicsOptional').vmssName]",
             "adminUsername": "[basics('adminUsername')]",
             "authenticationType": "[basics('authenticationType').authenticationType]",
             "adminPasswordOrSSHKey": "[coalesce(basics('authenticationType').password, basics('authenticationType').sshPublicKey)]",
-            "vmSize": "[steps('VirtualMachineConfig').vmSize]",
+            "vmSize": "[basics('vmSize')]",
+            "jdkVersion": "[basics('jdkVersion')]",
+            "virtualNetworkNewOrExisting": "[steps('NetworkingConfig').virtualNetwork.newOrExisting]",
+            "virtualNetworkName": "[steps('NetworkingConfig').virtualNetwork.name]",
+            "virtualNetworkResourceGroupName": "[steps('NetworkingConfig').virtualNetwork.resourceGroup]",
             
-            "virtualNetworkNewOrExisting": "[steps('VirtualMachineConfig').virtualNetwork.newOrExisting]",
-            "virtualNetworkName": "[steps('VirtualMachineConfig').virtualNetwork.name]",
-            "virtualNetworkResourceGroupName": "[steps('VirtualMachineConfig').virtualNetwork.resourceGroup]",
+            "addressPrefixes": "[steps('NetworkingConfig').virtualNetwork.addressPrefixes]",
+            "subnetName": "[steps('NetworkingConfig').virtualNetwork.subnets.jbossSubnet.name]",
+            "subnetPrefix": "[steps('NetworkingConfig').virtualNetwork.subnets.jbossSubnet.addressPrefix]",
             
-            "addressPrefixes": "[steps('VirtualMachineConfig').virtualNetwork.addressPrefixes]",
-            "subnetName": "[steps('VirtualMachineConfig').virtualNetwork.subnets.subnet1.name]",
-            "subnetPrefix": "[steps('VirtualMachineConfig').virtualNetwork.subnets.subnet1.addressPrefix]",
-            
-            "bootDiagnostics": "[steps('VirtualMachineConfig').bootDiagnostics]",
-            "bootStorageNewOrExisting": "[steps('VirtualMachineConfig').storageNewOrExisting]",
-            "existingStorageAccount": "[coalesce(steps('VirtualMachineConfig').existingStorageAccount,'')]",
-            "bootStorageAccountName": "[steps('VirtualMachineConfig').storageAccountName.value]",
-            "storageAccountKind": "[steps('VirtualMachineConfig').storageAccountKind]",
-            "bootStorageReplication": "[steps('VirtualMachineConfig').storageAccountType]",
-            "storageAccountResourceGroupName": "[if(and(equals(steps('VirtualMachineConfig').bootDiagnostics, 'on'),not(empty(steps('VirtualMachineConfig').existingStorageAccount))), first(skip(split(coalesce(first(filter(steps('VirtualMachineConfig').armApiControl.value, (item) => equals(steps('VirtualMachineConfig').existingStorageAccount,item.name))),parse('{\"id\":\"/////\"}')).id, '/'),4)), resourceGroup().name)]",
+            "bootDiagnostics": "[basics('basicsOptional').bootDiagnostics]",
+            "bootStorageNewOrExisting": "[basics('basicsOptional').storageNewOrExisting]",
+            "existingStorageAccount": "[coalesce(basics('basicsOptional').existingStorageAccount,'')]",
+            "bootStorageAccountName": "[basics('basicsOptional').storageAccountName]",
+            "storageAccountKind": "[basics('basicsOptional').storageAccountKind]",
+            "bootStorageReplication": "[basics('basicsOptional').storageAccountType]",
+            "storageAccountResourceGroupName": "[if(and(equals(basics('basicsOptional').bootDiagnostics, 'on'),not(empty(basics('basicsOptional').existingStorageAccount))), first(skip(split(coalesce(first(filter(basics('basicsOptional').armApiControl.value, (item) => equals(basics('basicsOptional').existingStorageAccount,item.name))),parse('{\"id\":\"/////\"}')).id, '/'),4)), resourceGroup().name)]",
 
-            "instanceCount": "[int(steps('VirtualMachineConfig').numberOfInstances)]",
+            "instanceCount": "[int(basics('numberOfInstances'))]",
             "jbossEAPUserName": "[steps('jbossEAPSettings').jbossEAPUserName]",
             "jbossEAPPassword": "[steps('jbossEAPSettings').jbossEAPPassword]",
             "rhsmUserName": "[steps('jbossEAPSettings').rhsmUserName]",

--- a/eap74-rhel8-payg-vmss/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-payg-vmss/src/main/bicep/mainTemplate.bicep
@@ -1,5 +1,5 @@
 @description('User name for the Virtual Machine')
-param adminUsername string
+param adminUsername string = 'jbossuser'
 
 @description('Type of authentication to use on the Virtual Machine')
 @allowed([
@@ -93,7 +93,7 @@ param subnetPrefix string = '10.0.0.0/24'
 
 @description('String used as a base for naming resources (9 characters or less). A hash is prepended to this string for some resources, and resource-specific information is appended')
 @maxLength(9)
-param vmssName string
+param vmssName string = 'jbossvmss'
 
 @description('Number of VM instances (100 or less)')
 @minValue(2)
@@ -102,6 +102,9 @@ param instanceCount int = 2
 
 @description('The size of the Virtual Machine scale set')
 param vmSize string = 'Standard_DS2_v2'
+
+@description('The JDK version of the Virtual Machine')
+param jdkVersion string = 'openjdk17'
 
 @description('The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated')
 param artifactsLocation string = deployment().properties.templateLink.uri
@@ -151,7 +154,7 @@ var linuxConfiguration = {
 var imageReference = {
   publisher: 'RedHat'
   offer: 'RHEL'
-  sku: '8_4'
+  sku: '8_6'
   version: 'latest'
 }
 var scriptFolder = 'bin'
@@ -163,7 +166,7 @@ module partnerCenterPid './modules/_pids/_empty.bicep' = {
   params: {}
 }
 
-resource bootStorageName 'Microsoft.Storage/storageAccounts@2021-04-01' = if (bootDiagnosticsCheck) {
+resource bootStorageName 'Microsoft.Storage/storageAccounts@2022-05-01' = if (bootDiagnosticsCheck) {
   name: bootStorageName_var
   location: location
   sku: {
@@ -175,7 +178,7 @@ resource bootStorageName 'Microsoft.Storage/storageAccounts@2021-04-01' = if (bo
   }
 }
 
-resource eapStorageAccountName 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+resource eapStorageAccountName 'Microsoft.Storage/storageAccounts@2022-05-01' = {
   name: eapStorageAccountName_var
   location: location
   sku: {
@@ -187,7 +190,7 @@ resource eapStorageAccountName 'Microsoft.Storage/storageAccounts@2021-04-01' = 
   }
 }
 
-resource eapStorageAccountName_default_containerName 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-06-01' = {
+resource eapStorageAccountName_default_containerName 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-05-01' = {
   name: '${eapStorageAccountName_var}/default/${containerName}'
   properties: {
     publicAccess: 'None'
@@ -197,7 +200,7 @@ resource eapStorageAccountName_default_containerName 'Microsoft.Storage/storageA
   ]
 }
 
-resource virtualNetworkName_resource 'Microsoft.Network/virtualNetworks@2020-11-01' = if (virtualNetworkNewOrExisting == 'new') {
+resource virtualNetworkName_resource 'Microsoft.Network/virtualNetworks@2022-05-01' = if (virtualNetworkNewOrExisting == 'new') {
   name: virtualNetworkName
   location: location
   tags: {
@@ -218,7 +221,7 @@ resource virtualNetworkName_resource 'Microsoft.Network/virtualNetworks@2020-11-
   }
 }
 
-resource vmssInstanceName 'Microsoft.Compute/virtualMachineScaleSets@2021-03-01' = {
+resource vmssInstanceName 'Microsoft.Compute/virtualMachineScaleSets@2022-08-01' = {
   name: vmssInstanceName_var
   location: location
   sku: {
@@ -294,7 +297,7 @@ resource vmssInstanceName 'Microsoft.Compute/virtualMachineScaleSets@2021-03-01'
                 ]
               }
               protectedSettings: {
-                commandToExecute: 'sh jbosseap-setup-redhat.sh ${scriptArgs} \'${jbossEAPUserName}\' \'${base64(jbossEAPPassword)}\' \'${rhsmUserName}\' \'${base64(rhsmPassword)}\' \'${rhsmPoolEAP}\' \'${eapStorageAccountName_var}\' \'${containerName}\' \'${base64(listKeys(eapStorageAccountName.id, '2021-06-01').keys[0].value)}\' \'${connectSatellite}\' \'${base64(satelliteActivationKey)}\' \'${base64(satelliteOrgName)}\' \'${satelliteFqdn}\''
+                commandToExecute: 'sh jbosseap-setup-redhat.sh ${scriptArgs} \'${jbossEAPUserName}\' \'${base64(jbossEAPPassword)}\' \'${rhsmUserName}\' \'${base64(rhsmPassword)}\' \'${rhsmPoolEAP}\' \'${eapStorageAccountName_var}\' \'${containerName}\' \'${base64(listKeys(eapStorageAccountName.id, '2021-06-01').keys[0].value)}\' \'${connectSatellite}\' \'${base64(satelliteActivationKey)}\' \'${base64(satelliteOrgName)}\' \'${satelliteFqdn}\' \'${jdkVersion}\''
               }
             }
           }
@@ -310,7 +313,7 @@ resource vmssInstanceName 'Microsoft.Compute/virtualMachineScaleSets@2021-03-01'
   ]
 }
 
-resource loadBalancersName 'Microsoft.Network/loadBalancers@2020-11-01' = {
+resource loadBalancersName 'Microsoft.Network/loadBalancers@2022-05-01' = {
   name: loadBalancersName_var
   location: location
   sku: {


### PR DESCRIPTION
## Change
* Support configurable OpenJDK versions (8, 11, 17)
* Update pipeline to avoid arm-ttk failures
* Reorg UX for usability improvments

## Test
* Pipeline
    * [Build PAYG VMSS artifact](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/3467579606)
    * [Validate payg-vmss offer](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/3467627440)
* Preview offer
    * Tested with OpenJDK 17, boot diagnostics enabled and existing VNET

Signed-off-by: Zheng Chang <zhengchang@microsoft.com>