### PR TITLE
On branch edburns-msft-dd-1679040-fix-arm-ttk-failure Fix ttk failure  "Username textbox jbossEAPUserName should not have a default value Line: 351, Column: 26"

### DIFF
--- a/eap74-rhel8-byos-vmss/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-byos-vmss/src/main/arm/createUiDefinition.json
@@ -348,12 +348,14 @@
                 "elements": [
                     {
                         "name": "jbossEAPUserName",
-                        "type": "Microsoft.Compute.UserNameTextBox",
+                        "type": "Microsoft.Common.TextBox",
                         "label": "JBoss EAP Admin username",
                         "defaultValue": "jbossadmin",
                         "osPlatform": "Linux",
                         "constraints": {
-                            "required": true
+                            "required": true,
+                            "regex": "^[a-z0-9A-Z]{1,30}$",
+                            "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
                         },
                         "toolTip": "Provide User name for JBoss EAP Manager"
                     },


### PR DESCRIPTION
…:

modified:   eap74-rhel8-byos-vmss/src/main/arm/createUiDefinition.json

Signed-off-by: Ed Burns <edburns@microsoft.com>