### PR TITLE
Support cookie-based affinity configuration

### DIFF
--- a/eap74-rhel8-byos-multivm/pom.xml
+++ b/eap74-rhel8-byos-multivm/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-byos-multivm</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.10</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/eap74-rhel8-byos-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-byos-multivm/src/main/arm/createUiDefinition.json
@@ -522,6 +522,13 @@
                             "icon": "Info",
                             "text": "This option will create a self-signed TLS/SSL certificate for gateway TLS/SSL termination. The Azure identity deploying this feature must have one of the following two sets of Azure role-based access control roles:<br> <li><a href='https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor'>Contributor</a> <b>and</b> <a href='https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#user-access-administrator'>User Access Administrator</a> of the current subscription.</li><li><a href='https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner'>Owner</a> of the current subscription.</li>"
                         }
+                    },
+                    {
+                        "name": "enableCookieBasedAffinity",
+                        "type": "Microsoft.Common.CheckBox",
+                        "label": "Enable cookie based affinity",
+                        "toolTip": "If checked, enable cookie based affinity",
+                        "visible": "[steps('AppGatewayConfig').enableAppGateway]"
                     }
                 ]
             },
@@ -741,6 +748,7 @@
             "satelliteOrgName": "[steps('satelliteServerSettings').satelliteOrgName]",
             "satelliteFqdn": "[steps('satelliteServerSettings').satelliteFqdn]",
             "enableAppGWIngress": "[steps('AppGatewayConfig').enableAppGateway]",
+            "enableCookieBasedAffinity": "[bool(steps('AppGatewayConfig').enableCookieBasedAffinity)]",
             "virtualNetworkNewOrExisting": "[if(steps('AppGatewayConfig').enableAppGateway, steps('NetworkingConfig').virtualNetworkWithAppGateway.newOrExisting, steps('NetworkingConfig').virtualNetworkWithoutAppGateway.newOrExisting)]"
         }
     }

--- a/eap74-rhel8-byos-multivm/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-byos-multivm/src/main/bicep/mainTemplate.bicep
@@ -160,6 +160,9 @@ param dnsNameforApplicationGateway string = 'jbossgw'
 @description('The name of the secret in the specified KeyVault whose value is the SSL Certificate Data for Appliation Gateway frontend TLS/SSL.')
 param keyVaultSSLCertDataSecretName string = 'kv-ssl-data'
 
+@description('true to enable cookie based affinity.')
+param enableCookieBasedAffinity bool = false
+
 var name_managedDomain = 'managed-domain'
 var name_fileshare = 'jbossshare'
 var containerName = 'eapblobcontainer'
@@ -324,6 +327,7 @@ module appgwDeployment 'modules/_appgateway.bicep' = if (enableAppGWIngress) {
     _pidAppgwStart: pids.outputs.appgwStart
     _pidAppgwEnd: pids.outputs.appgwEnd
     keyVaultName: name_keyVaultName
+    enableCookieBasedAffinity: enableCookieBasedAffinity
   }
   dependsOn: [
     appgwSecretDeployment

--- a/eap74-rhel8-byos-multivm/src/main/bicep/modules/_appgateway.bicep
+++ b/eap74-rhel8-byos-multivm/src/main/bicep/modules/_appgateway.bicep
@@ -11,6 +11,7 @@ param _pidAppgwEnd string = 'pid-networking-appgateway-end'
 param _pidAppgwStart string = 'pid-networking-appgateway-start'
 param keyVaultName string = 'keyVaultName'
 param sslCertDataSecretName string = 'sslCertDataSecretName'
+param enableCookieBasedAffinity bool = false
 
 
 var name_appGateway = appGatewayName
@@ -33,6 +34,7 @@ module appgwDeployment1 './_azure-resources/_appGateway.bicep' = {
     sslCertData: existingKeyvault.getSecret(sslCertDataSecretName)
     _pidAppgwStart: _pidAppgwStart
     _pidAppgwEnd: _pidAppgwEnd
+    enableCookieBasedAffinity: enableCookieBasedAffinity
   }
   dependsOn: [
     existingKeyvault

--- a/eap74-rhel8-byos-multivm/src/main/bicep/modules/_azure-resources/_appGateway.bicep
+++ b/eap74-rhel8-byos-multivm/src/main/bicep/modules/_azure-resources/_appGateway.bicep
@@ -11,6 +11,7 @@ param utcValue string = utcNow()
 param appGatewayName string = 'jbossappgw'
 param _pidAppgwEnd string = 'pid-networking-appgateway-end'
 param _pidAppgwStart string = 'pid-networking-appgateway-start'
+param enableCookieBasedAffinity bool = false
 
 var name_appGateway = appGatewayName
 var const_appGatewayFrontEndHTTPPort = 80
@@ -149,6 +150,7 @@ resource wafv2AppGateway 'Microsoft.Network/applicationGateways@2022-05-01' = {
         properties: {
           port: const_backendPort
           protocol: 'Http'
+          cookieBasedAffinity: enableCookieBasedAffinity? 'Enabled' :'Disabled'
         }
       }
     ]

--- a/eap74-rhel8-payg-multivm/pom.xml
+++ b/eap74-rhel8-payg-multivm/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-payg-multivm</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.11</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     

--- a/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
@@ -510,6 +510,13 @@
                             "icon": "Info",
                             "text": "This option will create a self-signed TLS/SSL certificate for gateway TLS/SSL termination. The Azure identity deploying this feature must have one of the following two sets of Azure role-based access control roles:<br> <li><a href='https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor'>Contributor</a> <b>and</b> <a href='https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#user-access-administrator'>User Access Administrator</a> of the current subscription.</li><li><a href='https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner'>Owner</a> of the current subscription.</li>"
                         }
+                    },
+                    {
+                        "name": "enableCookieBasedAffinity",
+                        "type": "Microsoft.Common.CheckBox",
+                        "label": "Enable cookie based affinity",
+                        "toolTip": "If checked, enable cookie based affinity",
+                        "visible": "[steps('AppGatewayConfig').enableAppGateway]"
                     }
                 ]
             },
@@ -727,6 +734,7 @@
             "satelliteOrgName": "[steps('satelliteServerSettings').satelliteOrgName]",
             "satelliteFqdn": "[steps('satelliteServerSettings').satelliteFqdn]",
             "enableAppGWIngress": "[steps('AppGatewayConfig').enableAppGateway]",
+            "enableCookieBasedAffinity": "[bool(steps('AppGatewayConfig').enableCookieBasedAffinity)]",
             "virtualNetworkNewOrExisting": "[if(steps('AppGatewayConfig').enableAppGateway, steps('NetworkingConfig').virtualNetworkWithAppGateway.newOrExisting, steps('NetworkingConfig').virtualNetworkWithoutAppGateway.newOrExisting)]"
         }
     }

--- a/eap74-rhel8-payg-multivm/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-payg-multivm/src/main/bicep/mainTemplate.bicep
@@ -157,6 +157,9 @@ param dnsNameforApplicationGateway string = 'jbossgw'
 @description('The name of the secret in the specified KeyVault whose value is the SSL Certificate Data for Appliation Gateway frontend TLS/SSL.')
 param keyVaultSSLCertDataSecretName string = 'kv-ssl-data'
 
+@description('true to enable cookie based affinity.')
+param enableCookieBasedAffinity bool = false
+
 var name_managedDomain = 'managed-domain'
 var name_fileshare = 'jbossshare'
 var containerName = 'eapblobcontainer'
@@ -316,6 +319,7 @@ module appgwDeployment 'modules/_appgateway.bicep' = if (enableAppGWIngress) {
     _pidAppgwStart: pids.outputs.appgwStart
     _pidAppgwEnd: pids.outputs.appgwEnd
     keyVaultName: name_keyVaultName
+    enableCookieBasedAffinity: enableCookieBasedAffinity
   }
   dependsOn: [
     appgwSecretDeployment

--- a/eap74-rhel8-payg-multivm/src/main/bicep/modules/_appgateway.bicep
+++ b/eap74-rhel8-payg-multivm/src/main/bicep/modules/_appgateway.bicep
@@ -11,6 +11,7 @@ param _pidAppgwEnd string = 'pid-networking-appgateway-end'
 param _pidAppgwStart string = 'pid-networking-appgateway-start'
 param keyVaultName string = 'keyVaultName'
 param sslCertDataSecretName string = 'sslCertDataSecretName'
+param enableCookieBasedAffinity bool = false
 
 
 var name_appGateway = appGatewayName
@@ -33,6 +34,7 @@ module appgwDeployment1 './_azure-resources/_appGateway.bicep' = {
     sslCertData: existingKeyvault.getSecret(sslCertDataSecretName)
     _pidAppgwStart: _pidAppgwStart
     _pidAppgwEnd: _pidAppgwEnd
+    enableCookieBasedAffinity: enableCookieBasedAffinity
   }
   dependsOn: [
     existingKeyvault

--- a/eap74-rhel8-payg-multivm/src/main/bicep/modules/_azure-resources/_appGateway.bicep
+++ b/eap74-rhel8-payg-multivm/src/main/bicep/modules/_azure-resources/_appGateway.bicep
@@ -11,6 +11,7 @@ param utcValue string = utcNow()
 param appGatewayName string = 'jbossappgw'
 param _pidAppgwEnd string = 'pid-networking-appgateway-end'
 param _pidAppgwStart string = 'pid-networking-appgateway-start'
+param enableCookieBasedAffinity bool = false
 
 var name_appGateway = appGatewayName
 var const_appGatewayFrontEndHTTPPort = 80
@@ -149,6 +150,7 @@ resource wafv2AppGateway 'Microsoft.Network/applicationGateways@2022-05-01' = {
         properties: {
           port: const_backendPort
           protocol: 'Http'
+          cookieBasedAffinity: enableCookieBasedAffinity? 'Enabled' :'Disabled'
         }
       }
     ]


### PR DESCRIPTION
## Please review & merge PR #131 before proceeding

## Change
This change addresses #135 
Add "Enable cookie based affinity" checkbox under Azure Application Gateway tab.

## Test 
Pipeline
* [Build PAYG multivm artifact](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/3691105423)
* [Build BYOS multivm artifact](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/3691104950)
* [Validate payg-multivm offer](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/3691459845)
* [Validate byos-multivm offer](https://github.com/zhengchang907/rhel-jboss-templates/actions/runs/3691110843)

Test offer
PAYG/BYOS with Azure Application Gateway enabled, with/without cookie based affinity enabled. Check the Http settings are as expected.

Signed-off-by: Zheng Chang <zhengchang@microsoft.com>