### PR TITLE
Support using existing ARO cluster

### DIFF
--- a/eap-aro/pom.xml
+++ b/eap-aro/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap-aro</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/eap-aro/src/main/arm/createUiDefinition.json
+++ b/eap-aro/src/main/arm/createUiDefinition.json
@@ -80,6 +80,26 @@
                 "bladeTitle": "Configure cluster",
                 "elements": [
                     {
+                        "name": "createCluster",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Create a new cluster?",
+                        "defaultValue": "Yes",
+                        "toolTip": "Select 'Yes' to create a new cluster, or select 'No' to provide an existing cluster.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": "true"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "false"
+                                }
+                            ],
+                            "required": true
+                        }
+                    },
+                    {
                         "name": "createClusterInfo",
                         "type": "Microsoft.Common.Section",
                         "label": "Provide information to create a new cluster",
@@ -157,18 +177,51 @@
                                 }
                             }
                         ],
-                        "visible": true
+                        "visible":  "[bool(steps('Cluster').createCluster)]"
+                    },
+                    {
+                        "name": "clusterInfo",
+                        "type": "Microsoft.Common.Section",
+                        "label": "Provide information for an existing cluster",
+                        "elements": [
+                            {
+                                "name": "errInfo",
+                                "type": "Microsoft.Common.InfoBox",
+                                "visible": "[equals(length(steps('Cluster').clusterInfo.clusterSelector.id), 0)]",
+                                "options": {
+                                    "icon": "Error",
+                                    "text": "You must select an existing Azure Red Hat OpenShift cluster in current subscription and location."
+                                }
+                            },
+                            {
+                                "name": "clusterSelector",
+                                "type": "Microsoft.Solutions.ResourceSelector",
+                                "label": "Select cluster",
+                                "toolTip": "Select the existing cluster.",
+                                "resourceType": "Microsoft.RedHatOpenShift/OpenShiftClusters",
+                                "options": {
+                                    "filter": {
+                                        "subscription": "onBasics",
+                                        "location": "onBasics"
+                                    }
+                                }
+                            }
+                        ],
+                        "visible": "[not(bool(steps('Cluster').createCluster))]"
                     }
                 ]
             }
         ],
         "outputs": {
             "location": "[location()]",
+            "createCluster": "[bool(steps('Cluster').createCluster)]",
             "pullSecret": "[steps('Cluster').createClusterInfo.pullSecret]",
             "aadClientId": "[steps('Cluster').createClusterInfo.aadClientId]",
             "aadClientSecret": "[steps('Cluster').createClusterInfo.aadClientSecret]",
             "aadObjectId": "[first(steps('Cluster').createClusterInfo.UserSPGraphRequest.transformed.objectID)]",
-            "rpObjectId": "[first(steps('Cluster').createClusterInfo.RPObjectIDGraphRequest.transformed.objectID)]"
+            "rpObjectId": "[first(steps('Cluster').createClusterInfo.RPObjectIDGraphRequest.transformed.objectID)]",
+            "clusterName": "[last(split(steps('Cluster').clusterInfo.clusterSelector.id, '/'))]",
+            "clusterRGName": "[last(take(split(steps('Cluster').clusterInfo.clusterSelector.id, '/'), 5))]"
         }
     }
 }

--- a/eap-aro/src/main/arm/createUiDefinition.json
+++ b/eap-aro/src/main/arm/createUiDefinition.json
@@ -72,9 +72,9 @@
         "steps": [
             {
                 "name": "Cluster",
-                "label": "Configure cluster",
+                "label": "ARO",
                 "subLabel": {
-                    "preValidation": "Provide required info for cluster configuration",
+                    "preValidation": "Provide required info for ARO configuration",
                     "postValidation": "Done"
                 },
                 "bladeTitle": "Configure cluster",

--- a/eap-aro/src/main/bicep/mainTemplate.bicep
+++ b/eap-aro/src/main/bicep/mainTemplate.bicep
@@ -121,16 +121,18 @@ resource uami 'Microsoft.ManagedIdentity/userAssignedIdentities@2022-01-31-previ
   name: const_identityName
 }
 
-resource uamiRoleAssign 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+
+// Assign Contributor role in subscription scope since we need the permission to get/update resource cross resource group.
+module deploymentScriptUAMICotibutorRoleAssignment 'modules/_rolesAssignment/_roleAssignmentinSubscription.bicep' = {
   name: name_roleAssignmentName
+  scope: subscription()
   dependsOn:[
     uami_resource
     roleResourceDefinition
   ]
-  properties:{
-    roleDefinitionId: roleResourceDefinition.id
+  params: {
+    roleDefinitionId: const_contribRole
     principalId: uami.properties.principalId
-    principalType: 'ServicePrincipal'
   }
 }
 

--- a/eap-aro/src/main/bicep/modules/_deployment-scripts/_ds-jbossSetup.bicep
+++ b/eap-aro/src/main/bicep/modules/_deployment-scripts/_ds-jbossSetup.bicep
@@ -14,6 +14,9 @@ param identity object = {}
 @description('Unique name for the cluster')
 param clusterName string
 
+@description('Name for the resource group of the existing cluster')
+param clusterRGName string = ''
+
 var const_scriptLocation = uri(artifactsLocation, 'scripts/')
 var const_setupJBossScript = 'jboss-setup.sh'
 var const_eapOperatorSubscriptionYaml = 'eap-operator-sub.yaml'
@@ -29,7 +32,7 @@ resource jbossSetup 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
     environmentVariables: [
       {
         name: 'RESOURCE_GROUP'
-        value: resourceGroup().name
+        value: clusterRGName
       }
       {
         name: 'CLUSTER_NAME'

--- a/eap-aro/src/main/bicep/modules/_rolesAssignment/_roleAssignmentinSubscription.bicep
+++ b/eap-aro/src/main/bicep/modules/_rolesAssignment/_roleAssignmentinSubscription.bicep
@@ -1,0 +1,25 @@
+targetScope = 'subscription'
+
+// https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
+param roleDefinitionId string = ''
+param principalId string = ''
+
+var name_roleAssignmentName = guid('${subscription().id}${principalId}Role assignment in subscription scope')
+
+// Get role resource id in subscription
+resource roleResourceDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  name: roleDefinitionId
+}
+
+// Assign role
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: name_roleAssignmentName
+  properties: {
+    description: 'Assign subscription scope role to User Assigned Managed Identity '
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: roleResourceDefinition.id
+  }
+}
+
+output roleId string = roleResourceDefinition.id

--- a/eap-aro/src/main/scripts/jboss-setup.sh
+++ b/eap-aro/src/main/scripts/jboss-setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# See https://github.com/WASdev/azure.liberty.aro/issues/60
+MAX_RETRIES=299
+
 # Define functions
 wait_login_complete() {
     username=$1


### PR DESCRIPTION
This PR addresses #132 

## Change
* Update UX and templates to support running offer on an existing ARO cluster
* Assign UAMI the `Contributor` role to the subscription instead of deployment resource group so it can access the ARO cluster in other resource groups.

**Please be noticed: the existing ARO is created following [Tutorial: Create an Azure Red Hat OpenShift 4 cluster](https://learn.microsoft.com/en-us/azure/openshift/tutorial-create-cluster) and deploying with a Red Hat pull secret is required for using our offer**.

## Test
Manually deployed offer with new/existing ARO cluster, check if the EAP operator is correctly installed.
