### PR TITLE
On branch edburns-msft-eap-163-policy-add Apply recommendations from @jamesfalkner. Allow setup script to run on Mac.

### DIFF
--- a/eap-aro/pom.xml
+++ b/eap-aro/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap-aro</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>


### PR DESCRIPTION
modified:   .github/workflows/setup-cluster-credentials.sh
modified:   eap-aro/pom.xml
modified:   eap-aro/src/main/scripts/jboss-setup.sh

Signed-off-by: Ed Burns <edburns@microsoft.com>