### PR TITLE
Support Microsoft SQL Server database connection

### DIFF
--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -6,9 +6,10 @@ on:
       databaseType:
         description: 'Database connection'
         required: true
-        default: 'postgresql'
+        default: 'mssqlserver'
         type: choice
         options:
+        - mssqlserver
         - postgresql
         - none
       isForDemo:
@@ -130,6 +131,22 @@ jobs:
             - name: Create Resource Group
               run: |
                 az group create -n ${{ env.dependencyResourceGroup}} -l ${{ env.location }}
+            - name: Deploy an instance of Azure SQL Database
+              if: ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}
+              run: |
+                az sql server create \
+                  --resource-group ${{ env.dependencyResourceGroup }} --name ${{ env.dbInstanceName }} \
+                  --admin-user testuser --admin-password ${{ env.dbPassword }} \
+                  --location ${{ env.location }}
+                host=$(az sql server show \
+                  --resource-group ${{ env.dependencyResourceGroup }} --name ${{ env.dbInstanceName }} \
+                  --query "fullyQualifiedDomainName" -o tsv)
+                # Allow Azure services to access
+                az sql server firewall-rule create \
+                  --resource-group ${{ env.dependencyResourceGroup }} --server ${{ env.dbInstanceName }} \
+                  --name "AllowAllAzureIps" --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
+                az sql db create --resource-group ${{ env.dependencyResourceGroup }} --server ${{ env.dbInstanceName }} --name testdb
+                echo "sqlserverHost=${host}" >> "$GITHUB_OUTPUT"
             - name: Deploy an instance of Azure Database for PostgreSQL
               id: deploy-postgresql
               if: ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}
@@ -210,7 +227,13 @@ jobs:
                 dsConnectionURL=jdbc:postgresql://contoso.postgres.database:5432/testdb
                 dbUser=contosoDbUser
                 dbPassword=contosoDbPwd
-                if ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
+                if ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}; then
+                  enableDB=true
+                  databaseType=mssqlserver
+                  dsConnectionURL="jdbc:sqlserver://${{ needs.deploy-dependent-resources.outputs.sqlserverHost }}:1433;database=testdb"
+                  dbUser=testuser@${{ env.dbInstanceName }}
+                  dbPassword=${{ env.dbPassword }}
+                elif ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ needs.deploy-dependent-resources.outputs.postgresqlHost }}:5432/testdb"
@@ -441,7 +464,13 @@ jobs:
                 dsConnectionURL=jdbc:postgresql://contoso.postgres.database:5432/testdb
                 dbUser=contosoDbUser
                 dbPassword=contosoDbPwd
-                if ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
+                if ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}; then
+                  enableDB=true
+                  databaseType=mssqlserver
+                  dsConnectionURL="jdbc:sqlserver://${{ needs.deploy-dependent-resources.outputs.sqlserverHost }}:1433;database=testdb"
+                  dbUser=testuser@${{ env.dbInstanceName }}
+                  dbPassword=${{ env.dbPassword }}
+                elif ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ needs.deploy-dependent-resources.outputs.postgresqlHost }}:5432/testdb"

--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -122,6 +122,7 @@ jobs:
         needs: preflight
         runs-on: ubuntu-latest
         outputs:
+          sqlserverHost: ${{ steps.deploy-mssqlserver.outputs.sqlserverHost }}
           postgresqlHost: ${{ steps.deploy-postgresql.outputs.postgresqlHost }}
         steps:
             - uses: azure/login@v1
@@ -132,6 +133,7 @@ jobs:
               run: |
                 az group create -n ${{ env.dependencyResourceGroup}} -l ${{ env.location }}
             - name: Deploy an instance of Azure SQL Database
+              id: deploy-mssqlserver
               if: ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}
               run: |
                 az sql server create \

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -6,9 +6,10 @@ on:
       databaseType:
         description: 'Database connection'
         required: true
-        default: 'postgresql'
+        default: 'mssqlserver'
         type: choice
         options:
+        - mssqlserver
         - postgresql
         - none
       isForDemo:
@@ -154,6 +155,23 @@ jobs:
               run: |
                   echo "accept terms for VM image"
                   az vm image terms accept --urn redhat:rhel-byos:rhel-lvm84:latest
+            - name: Deploy an instance of Azure SQL Database
+              if: ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}
+              run: |
+                az group create -n ${{ env.singleResourceGroup }} -l ${{ env.location }}
+                az sql server create \
+                  --resource-group ${{ env.singleResourceGroup }} --name ${{ env.dbInstanceName }} \
+                  --admin-user testuser --admin-password ${{ env.dbPassword }} \
+                  --location ${{ env.location }}
+                host=$(az sql server show \
+                  --resource-group ${{ env.singleResourceGroup }} --name ${{ env.dbInstanceName }} \
+                  --query "fullyQualifiedDomainName" -o tsv)
+                echo "sqlserverHost=${host}" >> $GITHUB_ENV
+                # Allow Azure services to access
+                az sql server firewall-rule create \
+                  --resource-group ${{ env.singleResourceGroup }} --server ${{ env.dbInstanceName }} \
+                  --name "AllowAllAzureIps" --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
+                az sql db create --resource-group ${{ env.singleResourceGroup }} --server ${{ env.dbInstanceName }} --name testdb
             - name: Deploy an instance of Azure Database for PostgreSQL
               if: ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}
               run: |
@@ -178,7 +196,13 @@ jobs:
                 dsConnectionURL=jdbc:postgresql://contoso.postgres.database:5432/testdb
                 dbUser=contosoDbUser
                 dbPassword=contosoDbPwd
-                if ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
+                if ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}; then
+                  enableDB=true
+                  databaseType=mssqlserver
+                  dsConnectionURL="jdbc:sqlserver://${{ env.sqlserverHost }}:1433;database=testdb"
+                  dbUser=testuser@${{ env.dbInstanceName }}
+                  dbPassword=${{ env.dbPassword }}
+                elif ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ env.postgresqlHost }}:5432/testdb"

--- a/.github/workflows/validate-byos-vmss.yaml
+++ b/.github/workflows/validate-byos-vmss.yaml
@@ -6,9 +6,10 @@ on:
       databaseType:
         description: 'Database connection'
         required: true
-        default: 'postgresql'
+        default: 'mssqlserver'
         type: choice
         options:
+        - mssqlserver
         - postgresql
         - none
       isForDemo:
@@ -163,6 +164,23 @@ jobs:
               run: |
                   echo "accept terms for VM image"
                   az vm image terms accept --urn redhat:rhel-byos:rhel-lvm84:latest
+            - name: Deploy an instance of Azure SQL Database
+              if: ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}
+              run: |
+                az group create -n ${{ env.vmssResourceGroup}} -l ${{ env.location }}
+                az sql server create \
+                  --resource-group ${{ env.vmssResourceGroup }} --name ${{ env.dbInstanceName }} \
+                  --admin-user testuser --admin-password ${{ env.dbPassword }} \
+                  --location ${{ env.location }}
+                host=$(az sql server show \
+                  --resource-group ${{ env.vmssResourceGroup }} --name ${{ env.dbInstanceName }} \
+                  --query "fullyQualifiedDomainName" -o tsv)
+                echo "sqlserverHost=${host}" >> $GITHUB_ENV
+                # Allow Azure services to access
+                az sql server firewall-rule create \
+                  --resource-group ${{ env.vmssResourceGroup }} --server ${{ env.dbInstanceName }} \
+                  --name "AllowAllAzureIps" --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
+                az sql db create --resource-group ${{ env.vmssResourceGroup }} --server ${{ env.dbInstanceName }} --name testdb
             - name: Deploy an instance of Azure Database for PostgreSQL
               if: ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}
               run: |
@@ -187,7 +205,13 @@ jobs:
                 dsConnectionURL=jdbc:postgresql://contoso.postgres.database:5432/testdb
                 dbUser=contosoDbUser
                 dbPassword=contosoDbPwd
-                if ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
+                if ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}; then
+                  enableDB=true
+                  databaseType=mssqlserver
+                  dsConnectionURL="jdbc:sqlserver://${{ env.sqlserverHost }}:1433;database=testdb"
+                  dbUser=testuser@${{ env.dbInstanceName }}
+                  dbPassword=${{ env.dbPassword }}
+                elif ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ env.postgresqlHost }}:5432/testdb"

--- a/.github/workflows/validate-payg-multivm.yaml
+++ b/.github/workflows/validate-payg-multivm.yaml
@@ -116,6 +116,7 @@ jobs:
         needs: preflight
         runs-on: ubuntu-latest
         outputs:
+          sqlserverHost: ${{ steps.deploy-mssqlserver.outputs.sqlserverHost }}
           postgresqlHost: ${{ steps.deploy-postgresql.outputs.postgresqlHost }}
         steps:
             - uses: azure/login@v1
@@ -126,6 +127,7 @@ jobs:
               run: |
                 az group create -n ${{ env.dependencyResourceGroup}} -l ${{ env.location }}
             - name: Deploy an instance of Azure SQL Database
+              id: deploy-mssqlserver
               if: ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}
               run: |
                 az sql server create \

--- a/.github/workflows/validate-payg-multivm.yaml
+++ b/.github/workflows/validate-payg-multivm.yaml
@@ -6,9 +6,10 @@ on:
       databaseType:
         description: 'Database connection'
         required: true
-        default: 'postgresql'
+        default: 'mssqlserver'
         type: choice
         options:
+        - mssqlserver
         - postgresql
         - none
       isForDemo:
@@ -124,6 +125,22 @@ jobs:
             - name: Create Resource Group
               run: |
                 az group create -n ${{ env.dependencyResourceGroup}} -l ${{ env.location }}
+            - name: Deploy an instance of Azure SQL Database
+              if: ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}
+              run: |
+                az sql server create \
+                  --resource-group ${{ env.dependencyResourceGroup }} --name ${{ env.dbInstanceName }} \
+                  --admin-user testuser --admin-password ${{ env.dbPassword }} \
+                  --location ${{ env.location }}
+                host=$(az sql server show \
+                  --resource-group ${{ env.dependencyResourceGroup }} --name ${{ env.dbInstanceName }} \
+                  --query "fullyQualifiedDomainName" -o tsv)
+                # Allow Azure services to access
+                az sql server firewall-rule create \
+                  --resource-group ${{ env.dependencyResourceGroup }} --server ${{ env.dbInstanceName }} \
+                  --name "AllowAllAzureIps" --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
+                az sql db create --resource-group ${{ env.dependencyResourceGroup }} --server ${{ env.dbInstanceName }} --name testdb
+                echo "sqlserverHost=${host}" >> "$GITHUB_OUTPUT"
             - name: Deploy an instance of Azure Database for PostgreSQL
               id: deploy-postgresql
               if: ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}
@@ -199,7 +216,13 @@ jobs:
                 dsConnectionURL=jdbc:postgresql://contoso.postgres.database:5432/testdb
                 dbUser=contosoDbUser
                 dbPassword=contosoDbPwd
-                if ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
+                if ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}; then
+                  enableDB=true
+                  databaseType=mssqlserver
+                  dsConnectionURL="jdbc:sqlserver://${{ needs.deploy-dependent-resources.outputs.sqlserverHost }}:1433;database=testdb"
+                  dbUser=testuser@${{ env.dbInstanceName }}
+                  dbPassword=${{ env.dbPassword }}
+                elif ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ needs.deploy-dependent-resources.outputs.postgresqlHost }}:5432/testdb"
@@ -424,7 +447,13 @@ jobs:
                 dsConnectionURL=jdbc:postgresql://contoso.postgres.database:5432/testdb
                 dbUser=contosoDbUser
                 dbPassword=contosoDbPwd
-                if ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
+                if ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}; then
+                  enableDB=true
+                  databaseType=mssqlserver
+                  dsConnectionURL="jdbc:sqlserver://${{ needs.deploy-dependent-resources.outputs.sqlserverHost }}:1433;database=testdb"
+                  dbUser=testuser@${{ env.dbInstanceName }}
+                  dbPassword=${{ env.dbPassword }}
+                elif ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ needs.deploy-dependent-resources.outputs.postgresqlHost }}:5432/testdb"

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -6,9 +6,10 @@ on:
       databaseType:
         description: 'Database connection'
         required: true
-        default: 'postgresql'
+        default: 'mssqlserver'
         type: choice
         options:
+        - mssqlserver
         - postgresql
         - none
       isForDemo:
@@ -149,6 +150,23 @@ jobs:
               id: azure-login
               with:
                 creds: ${{ env.azureCredentials }}
+            - name: Deploy an instance of Azure SQL Database
+              if: ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}
+              run: |
+                az group create -n ${{ env.singleResourceGroup }} -l ${{ env.location }}
+                az sql server create \
+                  --resource-group ${{ env.singleResourceGroup }} --name ${{ env.dbInstanceName }} \
+                  --admin-user testuser --admin-password ${{ env.dbPassword }} \
+                  --location ${{ env.location }}
+                host=$(az sql server show \
+                  --resource-group ${{ env.singleResourceGroup }} --name ${{ env.dbInstanceName }} \
+                  --query "fullyQualifiedDomainName" -o tsv)
+                echo "sqlserverHost=${host}" >> $GITHUB_ENV
+                # Allow Azure services to access
+                az sql server firewall-rule create \
+                  --resource-group ${{ env.singleResourceGroup }} --server ${{ env.dbInstanceName }} \
+                  --name "AllowAllAzureIps" --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
+                az sql db create --resource-group ${{ env.singleResourceGroup }} --server ${{ env.dbInstanceName }} --name testdb
             - name: Deploy an instance of Azure Database for PostgreSQL
               if: ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}
               run: |
@@ -173,7 +191,13 @@ jobs:
                 dsConnectionURL=jdbc:postgresql://contoso.postgres.database:5432/testdb
                 dbUser=contosoDbUser
                 dbPassword=contosoDbPwd
-                if ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
+                if ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}; then
+                  enableDB=true
+                  databaseType=mssqlserver
+                  dsConnectionURL="jdbc:sqlserver://${{ env.sqlserverHost }}:1433;database=testdb"
+                  dbUser=testuser@${{ env.dbInstanceName }}
+                  dbPassword=${{ env.dbPassword }}
+                elif ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ env.postgresqlHost }}:5432/testdb"

--- a/.github/workflows/validate-payg-vmss.yaml
+++ b/.github/workflows/validate-payg-vmss.yaml
@@ -6,9 +6,10 @@ on:
       databaseType:
         description: 'Database connection'
         required: true
-        default: 'postgresql'
+        default: 'mssqlserver'
         type: choice
         options:
+        - mssqlserver
         - postgresql
         - none
       isForDemo:
@@ -153,6 +154,23 @@ jobs:
               id: azure-login
               with:
                 creds: ${{ env.azureCredentials }}
+            - name: Deploy an instance of Azure SQL Database
+              if: ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}
+              run: |
+                az group create -n ${{ env.vmssResourceGroup}} -l ${{ env.location }}
+                az sql server create \
+                  --resource-group ${{ env.vmssResourceGroup }} --name ${{ env.dbInstanceName }} \
+                  --admin-user testuser --admin-password ${{ env.dbPassword }} \
+                  --location ${{ env.location }}
+                host=$(az sql server show \
+                  --resource-group ${{ env.vmssResourceGroup }} --name ${{ env.dbInstanceName }} \
+                  --query "fullyQualifiedDomainName" -o tsv)
+                echo "sqlserverHost=${host}" >> $GITHUB_ENV
+                # Allow Azure services to access
+                az sql server firewall-rule create \
+                  --resource-group ${{ env.vmssResourceGroup }} --server ${{ env.dbInstanceName }} \
+                  --name "AllowAllAzureIps" --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
+                az sql db create --resource-group ${{ env.vmssResourceGroup }} --server ${{ env.dbInstanceName }} --name testdb
             - name: Deploy an instance of Azure Database for PostgreSQL
               if: ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}
               run: |
@@ -177,7 +195,13 @@ jobs:
                 dsConnectionURL=jdbc:postgresql://contoso.postgres.database:5432/testdb
                 dbUser=contosoDbUser
                 dbPassword=contosoDbPwd
-                if ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
+                if ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}; then
+                  enableDB=true
+                  databaseType=mssqlserver
+                  dsConnectionURL="jdbc:sqlserver://${{ env.sqlserverHost }}:1433;database=testdb"
+                  dbUser=testuser@${{ env.dbInstanceName }}
+                  dbPassword=${{ env.dbPassword }}
+                elif ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ env.postgresqlHost }}:5432/testdb"

--- a/eap74-rhel8-byos-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-byos-multivm/src/main/arm/createUiDefinition.json
@@ -747,9 +747,13 @@
                                 "type": "Microsoft.Common.DropDown",
                                 "label": "Choose database type",
                                 "toolTip": "Choose database type",
-                                "defaultValue": "PostgreSQL",
+                                "defaultValue": "Microsoft SQL Server",
                                 "constraints": {
                                     "allowedValues": [
+                                        {
+                                            "label": "Microsoft SQL Server",
+                                            "value": "mssqlserver"
+                                        },
                                         {
                                             "label": "PostgreSQL",
                                             "value": "postgresql"
@@ -771,6 +775,45 @@
                                     "validationMessage": "The value must be 1-30 characters long and must only contain letters, numbers, hyphens (-), underscores (_), periods (.) and slashes (/)."
                                 },
                                 "visible": true
+                            },
+                            {
+                                "name": "sqlserverDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:sqlserver://&lt;host&gt;:&lt;port&gt;;database=&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:sqlserver:\/\/([^\/]+):([0-9]+);database=([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'mssqlserver')]"
+                            },
+                            {
+                                "name": "oracleDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:oracle:thin:@&lt;host&gt;:&lt;port&gt;/&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:oracle:thin:@([^\/]+):([0-9]+)\/([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'oracle')]"
+                            },
+                            {
+                                "name": "mysqlDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:mysql://&lt;host&gt;:&lt;port&gt;/&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:mysql:\/\/([^\/]+):([0-9]+)\/([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql')]"
                             },
                             {
                                 "name": "postgresDsConnectionURL",
@@ -863,7 +906,7 @@
             "enableDB": "[bool(steps('section_database').enableDB)]",
             "databaseType": "[steps('section_database').databaseConnectionInfo.databaseType]",
             "jdbcDataSourceJNDIName": "[steps('section_database').databaseConnectionInfo.jdbcDataSourceJNDIName]",
-            "dsConnectionURL": "[steps('section_database').databaseConnectionInfo.postgresDsConnectionURL]",
+            "dsConnectionURL": "[if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'oracle'), steps('section_database').databaseConnectionInfo.oracleDsConnectionURL, if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql'), steps('section_database').databaseConnectionInfo.mysqlDsConnectionURL, if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'postgresql'), steps('section_database').databaseConnectionInfo.postgresDsConnectionURL, steps('section_database').databaseConnectionInfo.sqlserverDsConnectionURL)))]",
             "dbUser": "[steps('section_database').databaseConnectionInfo.dbUser]",
             "dbPassword": "[steps('section_database').databaseConnectionInfo.dbPassword]"
         }

--- a/eap74-rhel8-byos-multivm/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-byos-multivm/src/main/bicep/mainTemplate.bicep
@@ -166,6 +166,7 @@ param enableCookieBasedAffinity bool = false
 @description('Boolean value indicating if user wants to enable database connection.')
 param enableDB bool = false
 @allowed([
+  'mssqlserver'
   'postgresql'
 ])
 @description('One of the supported database types')

--- a/eap74-rhel8-byos-multivm/src/main/bicep/modules/_deployment-scripts/_ds-jbossEAPSetup.bicep
+++ b/eap74-rhel8-byos-multivm/src/main/bicep/modules/_deployment-scripts/_ds-jbossEAPSetup.bicep
@@ -85,6 +85,7 @@ param nicName string
 @description('Boolean value indicating if user wants to enable database connection.')
 param enableDB bool = false
 @allowed([
+  'mssqlserver'
   'postgresql'
 ])
 @description('One of the supported database types')

--- a/eap74-rhel8-byos-multivm/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap74-rhel8-byos-multivm/src/main/scripts/create-ds-mssqlserver.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+set -Eeuo pipefail
+
+log() {
+    while IFS= read -r line; do
+        printf '%s %s\n' "$(date "+%Y-%m-%d %H:%M:%S")" "$line" >> /var/log/jbosseap.install.log
+    done
+}
+
+# Parameters
+eapRootPath=$1                                      # Root path of JBoss EAP
+jdbcDataSourceName=$2                               # JDBC Datasource name
+jdbcDSJNDIName=$(echo "${3}" | base64 -d)           # JDBC Datasource JNDI name
+dsConnectionString=$(echo "${4}" | base64 -d)       # JDBC Datasource connection String
+databaseUser=$(echo "${5}" | base64 -d)             # Database username
+databasePassword=$(echo "${6}" | base64 -d)         # Database user password
+isManagedDomain=$7                                  # true if the server is in a managed domain, false otherwise
+isSlaveServer=$8                                    # true if it's a slave server of a managed domain, false otherwise
+
+# Create JDBC driver and module directory
+jdbcDriverModuleDirectory="$eapRootPath"/modules/com/microsoft/sqlserver/main
+mkdir -p "$jdbcDriverModuleDirectory"
+
+# Download JDBC driver
+version=11.2.1.jre8
+jdbcDriverName=mssql-jdbc-${version}.jar
+curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${version}/${jdbcDriverName}
+
+# Create module for JDBC driver
+jdbcDriverModule=module.xml
+cat <<EOF >${jdbcDriverModule}
+<?xml version="1.0" ?>
+<module xmlns="urn:jboss:module:1.1" name="com.microsoft.sqlserver">
+  <resources>
+    <resource-root path="${jdbcDriverName}"/>
+  </resources>
+  <dependencies>
+    <module name="javaee.api"/>
+    <module name="sun.jdk"/>
+    <module name="ibm.jdk"/>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+    <module name="javax.xml.bind.api"/>
+  </dependencies>
+</module>
+EOF
+chmod 644 $jdbcDriverModule
+mv $jdbcDriverModule $jdbcDriverModuleDirectory/$jdbcDriverModule
+
+if [ $isManagedDomain == "false" ]; then
+    # Register JDBC driver
+    sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \
+    "/subsystem=datasources/jdbc-driver=sqlserver:add(driver-name=sqlserver,driver-module-name=com.microsoft.sqlserver,driver-xa-datasource-class-name=com.microsoft.sqlserver.jdbc.SQLServerXADataSource)" | log
+
+    # Create data source
+    echo "data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=*** --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter" | log
+    sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \
+    "data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=${databasePassword} --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter"
+elif [ $isSlaveServer == "false" ]; then
+    # Register JDBC driver
+    sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --controller=$(hostname -I) --echo-command \
+    "/profile=ha/subsystem=datasources/jdbc-driver=sqlserver:add(driver-name=sqlserver,driver-module-name=com.microsoft.sqlserver,driver-xa-datasource-class-name=com.microsoft.sqlserver.jdbc.SQLServerXADataSource)" | log
+
+    # Create data source
+    echo "data-source add --profile=ha --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=*** --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter" | log
+    sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --controller=$(hostname -I) --echo-command \
+    "data-source add --driver-name=sqlserver --profile=ha --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=${databasePassword} --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter"
+fi

--- a/eap74-rhel8-byos-multivm/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap74-rhel8-byos-multivm/src/main/scripts/create-ds-mssqlserver.sh
@@ -22,9 +22,9 @@ jdbcDriverModuleDirectory="$eapRootPath"/modules/com/microsoft/sqlserver/main
 mkdir -p "$jdbcDriverModuleDirectory"
 
 # Download JDBC driver
-version=11.2.1.jre8
-jdbcDriverName=mssql-jdbc-${version}.jar
-curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${version}/${jdbcDriverName}
+jdbcDriverVersion=11.2.1.jre8
+jdbcDriverName=mssql-jdbc-${jdbcDriverVersion}.jar
+curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${jdbcDriverVersion}/${jdbcDriverName}
 
 # Create module for JDBC driver
 jdbcDriverModule=module.xml

--- a/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-setup-redhat.sh
@@ -9,6 +9,7 @@ eval unwrapped_artifactsLocation=${ARTIFACTS_LOCATION}
 
 # Script URIs for creating data source connection
 postgresqlDSScriptUri="${unwrapped_artifactsLocation}${PATH_TO_SCRIPT}/create-ds-postgresql.sh"
+mssqlserverDSScriptUri="${unwrapped_artifactsLocation}${PATH_TO_SCRIPT}/create-ds-mssqlserver.sh"
 
 if [ "${CONFIGURATION_MODE}" != "managed-domain" ]; then
     # Configure standalone host
@@ -25,7 +26,7 @@ if [ "${CONFIGURATION_MODE}" != "managed-domain" ]; then
         --vm-name ${VM_NAME_PREFIX}${i} \
         --publisher Microsoft.Azure.Extensions \
         --version 2.0 \
-        --settings "{\"fileUris\": [\"${standaloneScriptUri}\", \"${postgresqlDSScriptUri}\"]}" \
+        --settings "{\"fileUris\": [\"${standaloneScriptUri}\", \"${postgresqlDSScriptUri}\", \"${mssqlserverDSScriptUri}\"]}" \
         --protected-settings "{\"commandToExecute\":\"sh jbosseap-setup-standalone.sh -a ${ARTIFACTS_LOCATION} -t ${ARTIFACTS_LOCATION_SAS_TOKEN} -p ${PATH_TO_FILE} -f ${FILE_TO_DOWNLOAD} ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${RHEL_POOL} ${JDK_VERSION} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY_BASE64} ${SATELLITE_ORG_NAME_BASE64} ${SATELLITE_VM_FQDN} ${ENABLE_DB} ${DATABASE_TYPE} ${JDBC_DATA_SOURCE_JNDI_NAME_BASE64} ${DS_CONNECTION_URL_BASE64} ${DB_USER_BASE64} ${DB_PASSWORD_BASE64}\"}"
         if [ $? != 0 ] ; then echo  "Failed to configure standalone host ${VM_NAME_PREFIX}${i}"; exit 1;  fi
         echo "standalone ${VM_NAME_PREFIX}${i} extension execution completed"
@@ -56,7 +57,7 @@ else
         --vm-name ${ADMIN_VM_NAME} \
         --publisher Microsoft.Azure.Extensions \
         --version 2.0 \
-        --settings "{\"fileUris\": [\"${masterScriptUri}\", \"${enableElytronSe17DomainCliUri}\", \"${postgresqlDSScriptUri}\"]}" \
+        --settings "{\"fileUris\": [\"${masterScriptUri}\", \"${enableElytronSe17DomainCliUri}\", \"${postgresqlDSScriptUri}\", \"${mssqlserverDSScriptUri}\"]}" \
         --protected-settings "{\"commandToExecute\":\"sh jbosseap-setup-master.sh ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${RHEL_POOL} ${JDK_VERSION} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${privateEndpointIp} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY_BASE64} ${SATELLITE_ORG_NAME_BASE64} ${SATELLITE_VM_FQDN} ${ENABLE_DB} ${DATABASE_TYPE} ${JDBC_DATA_SOURCE_JNDI_NAME_BASE64} ${DS_CONNECTION_URL_BASE64} ${DB_USER_BASE64} ${DB_PASSWORD_BASE64}\"}"
         if [ $? != 0 ] ; then echo  "Failed to configure domain controller host: ${ADMIN_VM_NAME}"; exit 1;  fi
         echo "Domain controller VM extension execution completed"
@@ -74,7 +75,7 @@ else
         --vm-name ${VM_NAME_PREFIX}${i} \
         --publisher Microsoft.Azure.Extensions \
         --version 2.0 \
-        --settings "{\"fileUris\": [\"${slaveScriptUri}\", \"${enableElytronSe17DomainCliUri}\", \"${postgresqlDSScriptUri}\"]}" \
+        --settings "{\"fileUris\": [\"${slaveScriptUri}\", \"${enableElytronSe17DomainCliUri}\", \"${postgresqlDSScriptUri}\", \"${mssqlserverDSScriptUri}\"]}" \
         --protected-settings "{\"commandToExecute\":\"sh jbosseap-setup-slave.sh ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${RHEL_POOL} ${JDK_VERSION} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${privateEndpointIp} ${DOMAIN_CONTROLLER_PRIVATE_IP} ${NUMBER_OF_SERVER_INSTANCE} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY_BASE64} ${SATELLITE_ORG_NAME_BASE64} ${SATELLITE_VM_FQDN} ${ENABLE_DB} ${DATABASE_TYPE} ${JDBC_DATA_SOURCE_JNDI_NAME_BASE64} ${DS_CONNECTION_URL_BASE64} ${DB_USER_BASE64} ${DB_PASSWORD_BASE64}\"}"
         if [ $? != 0 ] ; then echo  "Failed to configure domain slave host: ${VM_NAME_PREFIX}${i}"; exit 1;  fi
         echo "Slave ${VM_NAME_PREFIX}${i} extension execution completed"

--- a/eap74-rhel8-byos-vmss/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-byos-vmss/src/main/arm/createUiDefinition.json
@@ -702,9 +702,13 @@
                                 "type": "Microsoft.Common.DropDown",
                                 "label": "Choose database type",
                                 "toolTip": "Choose database type",
-                                "defaultValue": "PostgreSQL",
+                                "defaultValue": "Microsoft SQL Server",
                                 "constraints": {
                                     "allowedValues": [
+                                        {
+                                            "label": "Microsoft SQL Server",
+                                            "value": "mssqlserver"
+                                        },
                                         {
                                             "label": "PostgreSQL",
                                             "value": "postgresql"
@@ -726,6 +730,45 @@
                                     "validationMessage": "The value must be 1-30 characters long and must only contain letters, numbers, hyphens (-), underscores (_), periods (.) and slashes (/)."
                                 },
                                 "visible": true
+                            },
+                            {
+                                "name": "sqlserverDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:sqlserver://&lt;host&gt;:&lt;port&gt;;database=&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:sqlserver:\/\/([^\/]+):([0-9]+);database=([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'mssqlserver')]"
+                            },
+                            {
+                                "name": "oracleDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:oracle:thin:@&lt;host&gt;:&lt;port&gt;/&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:oracle:thin:@([^\/]+):([0-9]+)\/([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'oracle')]"
+                            },
+                            {
+                                "name": "mysqlDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:mysql://&lt;host&gt;:&lt;port&gt;/&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:mysql:\/\/([^\/]+):([0-9]+)\/([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql')]"
                             },
                             {
                                 "name": "postgresDsConnectionURL",
@@ -815,7 +858,7 @@
             "enableDB": "[bool(steps('section_database').enableDB)]",
             "databaseType": "[steps('section_database').databaseConnectionInfo.databaseType]",
             "jdbcDataSourceJNDIName": "[steps('section_database').databaseConnectionInfo.jdbcDataSourceJNDIName]",
-            "dsConnectionURL": "[steps('section_database').databaseConnectionInfo.postgresDsConnectionURL]",
+            "dsConnectionURL": "[if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'oracle'), steps('section_database').databaseConnectionInfo.oracleDsConnectionURL, if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql'), steps('section_database').databaseConnectionInfo.mysqlDsConnectionURL, if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'postgresql'), steps('section_database').databaseConnectionInfo.postgresDsConnectionURL, steps('section_database').databaseConnectionInfo.sqlserverDsConnectionURL)))]",
             "dbUser": "[steps('section_database').databaseConnectionInfo.dbUser]",
             "dbPassword": "[steps('section_database').databaseConnectionInfo.dbPassword]"
         }

--- a/eap74-rhel8-byos-vmss/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-byos-vmss/src/main/bicep/mainTemplate.bicep
@@ -157,6 +157,7 @@ param enableCookieBasedAffinity bool = false
 @description('Boolean value indicating, if user wants to enable database connection.')
 param enableDB bool = false
 @allowed([
+  'mssqlserver'
   'postgresql'
 ])
 @description('One of the supported database types')
@@ -499,6 +500,7 @@ resource vmssInstanceName 'Microsoft.Compute/virtualMachineScaleSets@2022-08-01'
                 fileUris: [
                   uri(artifactsLocation, 'scripts/jbosseap-setup-redhat.sh${artifactsLocationSasToken}')
                   uri(artifactsLocation, 'scripts/create-ds-postgresql.sh${artifactsLocationSasToken}')
+                  uri(artifactsLocation, 'scripts/create-ds-mssqlserver.sh${artifactsLocationSasToken}')
                 ]
               }
               protectedSettings: {

--- a/eap74-rhel8-byos-vmss/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap74-rhel8-byos-vmss/src/main/scripts/create-ds-mssqlserver.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -Eeuo pipefail
+
+log() {
+    while IFS= read -r line; do
+        printf '%s %s\n' "$(date "+%Y-%m-%d %H:%M:%S")" "$line" >> /var/log/jbosseap.install.log
+    done
+}
+
+# Parameters
+eapRootPath=$1                                      # Root path of JBoss EAP
+jdbcDataSourceName=$2                               # JDBC Datasource name
+jdbcDSJNDIName=$(echo "${3}" | base64 -d)           # JDBC Datasource JNDI name
+dsConnectionString=$(echo "${4}" | base64 -d)       # JDBC Datasource connection String
+databaseUser=$(echo "${5}" | base64 -d)             # Database username
+databasePassword=$(echo "${6}" | base64 -d)         # Database user password
+
+# Create JDBC driver and module directory
+jdbcDriverModuleDirectory="$eapRootPath"/modules/com/microsoft/sqlserver/main
+mkdir -p "$jdbcDriverModuleDirectory"
+
+# Download JDBC driver
+version=11.2.1.jre8
+jdbcDriverName=mssql-jdbc-${version}.jar
+curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${version}/${jdbcDriverName}
+
+# Create module for JDBC driver
+jdbcDriverModule=module.xml
+cat <<EOF >${jdbcDriverModule}
+<?xml version="1.0" ?>
+<module xmlns="urn:jboss:module:1.1" name="com.microsoft.sqlserver">
+  <resources>
+    <resource-root path="${jdbcDriverName}"/>
+  </resources>
+  <dependencies>
+    <module name="javaee.api"/>
+    <module name="sun.jdk"/>
+    <module name="ibm.jdk"/>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+    <module name="javax.xml.bind.api"/>
+  </dependencies>
+</module>
+EOF
+chmod 644 $jdbcDriverModule
+mv $jdbcDriverModule $jdbcDriverModuleDirectory/$jdbcDriverModule
+
+# Register JDBC driver
+sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \
+"/subsystem=datasources/jdbc-driver=sqlserver:add(driver-name=sqlserver,driver-module-name=com.microsoft.sqlserver,driver-xa-datasource-class-name=com.microsoft.sqlserver.jdbc.SQLServerXADataSource)" | log
+
+# Create data source
+echo "data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=*** --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter" | log
+sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \
+"data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=${databasePassword} --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter"

--- a/eap74-rhel8-byos-vmss/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap74-rhel8-byos-vmss/src/main/scripts/create-ds-mssqlserver.sh
@@ -20,9 +20,9 @@ jdbcDriverModuleDirectory="$eapRootPath"/modules/com/microsoft/sqlserver/main
 mkdir -p "$jdbcDriverModuleDirectory"
 
 # Download JDBC driver
-version=11.2.1.jre8
-jdbcDriverName=mssql-jdbc-${version}.jar
-curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${version}/${jdbcDriverName}
+jdbcDriverVersion=11.2.1.jre8
+jdbcDriverName=mssql-jdbc-${jdbcDriverVersion}.jar
+curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${jdbcDriverVersion}/${jdbcDriverName}
 
 # Create module for JDBC driver
 jdbcDriverModule=module.xml

--- a/eap74-rhel8-byos/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-byos/src/main/arm/createUiDefinition.json
@@ -578,9 +578,13 @@
                                 "type": "Microsoft.Common.DropDown",
                                 "label": "Choose database type",
                                 "toolTip": "Choose database type",
-                                "defaultValue": "PostgreSQL",
+                                "defaultValue": "Microsoft SQL Server",
                                 "constraints": {
                                     "allowedValues": [
+                                        {
+                                            "label": "Microsoft SQL Server",
+                                            "value": "mssqlserver"
+                                        },
                                         {
                                             "label": "PostgreSQL",
                                             "value": "postgresql"
@@ -602,6 +606,45 @@
                                     "validationMessage": "The value must be 1-30 characters long and must only contain letters, numbers, hyphens (-), underscores (_), periods (.) and slashes (/)."
                                 },
                                 "visible": true
+                            },
+                            {
+                                "name": "sqlserverDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:sqlserver://&lt;host&gt;:&lt;port&gt;;database=&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:sqlserver:\/\/([^\/]+):([0-9]+);database=([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'mssqlserver')]"
+                            },
+                            {
+                                "name": "oracleDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:oracle:thin:@&lt;host&gt;:&lt;port&gt;/&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:oracle:thin:@([^\/]+):([0-9]+)\/([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'oracle')]"
+                            },
+                            {
+                                "name": "mysqlDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:mysql://&lt;host&gt;:&lt;port&gt;/&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:mysql:\/\/([^\/]+):([0-9]+)\/([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql')]"
                             },
                             {
                                 "name": "postgresDsConnectionURL",
@@ -690,7 +733,7 @@
             "enableDB": "[bool(steps('section_database').enableDB)]",
             "databaseType": "[steps('section_database').databaseConnectionInfo.databaseType]",
             "jdbcDataSourceJNDIName": "[steps('section_database').databaseConnectionInfo.jdbcDataSourceJNDIName]",
-            "dsConnectionURL": "[steps('section_database').databaseConnectionInfo.postgresDsConnectionURL]",
+            "dsConnectionURL": "[if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'oracle'), steps('section_database').databaseConnectionInfo.oracleDsConnectionURL, if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql'), steps('section_database').databaseConnectionInfo.mysqlDsConnectionURL, if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'postgresql'), steps('section_database').databaseConnectionInfo.postgresDsConnectionURL, steps('section_database').databaseConnectionInfo.sqlserverDsConnectionURL)))]",
             "dbUser": "[steps('section_database').databaseConnectionInfo.dbUser]",
             "dbPassword": "[steps('section_database').databaseConnectionInfo.dbPassword]"
         }

--- a/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
@@ -115,6 +115,7 @@ param satelliteFqdn string = newGuid()
 @description('Boolean value indicating, if user wants to enable database connection.')
 param enableDB bool = false
 @allowed([
+  'mssqlserver'
   'postgresql'
 ])
 @description('One of the supported database types')
@@ -314,6 +315,7 @@ resource vmName_jbosseap_setup_extension 'Microsoft.Compute/virtualMachines/exte
       fileUris: [
         uri(artifactsLocation, 'scripts/jbosseap-setup-redhat.sh${artifactsLocationSasToken}')
         uri(artifactsLocation, 'scripts/create-ds-postgresql.sh${artifactsLocationSasToken}')
+        uri(artifactsLocation, 'scripts/create-ds-mssqlserver.sh${artifactsLocationSasToken}')
       ]
     }
     protectedSettings: {

--- a/eap74-rhel8-byos/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap74-rhel8-byos/src/main/scripts/create-ds-mssqlserver.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -Eeuo pipefail
+
+log() {
+    while IFS= read -r line; do
+        printf '%s %s\n' "$(date "+%Y-%m-%d %H:%M:%S")" "$line" >> /var/log/jbosseap.install.log
+    done
+}
+
+# Parameters
+eapRootPath=$1                                      # Root path of JBoss EAP
+jdbcDataSourceName=$2                               # JDBC Datasource name
+jdbcDSJNDIName=$(echo "${3}" | base64 -d)           # JDBC Datasource JNDI name
+dsConnectionString=$(echo "${4}" | base64 -d)       # JDBC Datasource connection String
+databaseUser=$(echo "${5}" | base64 -d)             # Database username
+databasePassword=$(echo "${6}" | base64 -d)         # Database user password
+
+# Create JDBC driver and module directory
+jdbcDriverModuleDirectory="$eapRootPath"/modules/com/microsoft/sqlserver/main
+mkdir -p "$jdbcDriverModuleDirectory"
+
+# Download JDBC driver
+version=11.2.1.jre8
+jdbcDriverName=mssql-jdbc-${version}.jar
+curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${version}/${jdbcDriverName}
+
+# Create module for JDBC driver
+jdbcDriverModule=module.xml
+cat <<EOF >${jdbcDriverModule}
+<?xml version="1.0" ?>
+<module xmlns="urn:jboss:module:1.1" name="com.microsoft.sqlserver">
+  <resources>
+    <resource-root path="${jdbcDriverName}"/>
+  </resources>
+  <dependencies>
+    <module name="javaee.api"/>
+    <module name="sun.jdk"/>
+    <module name="ibm.jdk"/>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+    <module name="javax.xml.bind.api"/>
+  </dependencies>
+</module>
+EOF
+chmod 644 $jdbcDriverModule
+mv $jdbcDriverModule $jdbcDriverModuleDirectory/$jdbcDriverModule
+
+# Register JDBC driver
+sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \
+"/subsystem=datasources/jdbc-driver=sqlserver:add(driver-name=sqlserver,driver-module-name=com.microsoft.sqlserver,driver-xa-datasource-class-name=com.microsoft.sqlserver.jdbc.SQLServerXADataSource)" | log
+
+# Create data source
+echo "data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=*** --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter" | log
+sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \
+"data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=${databasePassword} --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter"

--- a/eap74-rhel8-byos/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap74-rhel8-byos/src/main/scripts/create-ds-mssqlserver.sh
@@ -20,9 +20,9 @@ jdbcDriverModuleDirectory="$eapRootPath"/modules/com/microsoft/sqlserver/main
 mkdir -p "$jdbcDriverModuleDirectory"
 
 # Download JDBC driver
-version=11.2.1.jre8
-jdbcDriverName=mssql-jdbc-${version}.jar
-curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${version}/${jdbcDriverName}
+jdbcDriverVersion=11.2.1.jre8
+jdbcDriverName=mssql-jdbc-${jdbcDriverVersion}.jar
+curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${jdbcDriverVersion}/${jdbcDriverName}
 
 # Create module for JDBC driver
 jdbcDriverModule=module.xml

--- a/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
@@ -735,9 +735,13 @@
                                 "type": "Microsoft.Common.DropDown",
                                 "label": "Choose database type",
                                 "toolTip": "Choose database type",
-                                "defaultValue": "PostgreSQL",
+                                "defaultValue": "Microsoft SQL Server",
                                 "constraints": {
                                     "allowedValues": [
+                                        {
+                                            "label": "Microsoft SQL Server",
+                                            "value": "mssqlserver"
+                                        },
                                         {
                                             "label": "PostgreSQL",
                                             "value": "postgresql"
@@ -759,6 +763,45 @@
                                     "validationMessage": "The value must be 1-30 characters long and must only contain letters, numbers, hyphens (-), underscores (_), periods (.) and slashes (/)."
                                 },
                                 "visible": true
+                            },
+                            {
+                                "name": "sqlserverDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:sqlserver://&lt;host&gt;:&lt;port&gt;;database=&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:sqlserver:\/\/([^\/]+):([0-9]+);database=([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'mssqlserver')]"
+                            },
+                            {
+                                "name": "oracleDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:oracle:thin:@&lt;host&gt;:&lt;port&gt;/&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:oracle:thin:@([^\/]+):([0-9]+)\/([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'oracle')]"
+                            },
+                            {
+                                "name": "mysqlDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:mysql://&lt;host&gt;:&lt;port&gt;/&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:mysql:\/\/([^\/]+):([0-9]+)\/([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql')]"
                             },
                             {
                                 "name": "postgresDsConnectionURL",
@@ -849,7 +892,7 @@
             "enableDB": "[bool(steps('section_database').enableDB)]",
             "databaseType": "[steps('section_database').databaseConnectionInfo.databaseType]",
             "jdbcDataSourceJNDIName": "[steps('section_database').databaseConnectionInfo.jdbcDataSourceJNDIName]",
-            "dsConnectionURL": "[steps('section_database').databaseConnectionInfo.postgresDsConnectionURL]",
+            "dsConnectionURL": "[if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'oracle'), steps('section_database').databaseConnectionInfo.oracleDsConnectionURL, if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql'), steps('section_database').databaseConnectionInfo.mysqlDsConnectionURL, if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'postgresql'), steps('section_database').databaseConnectionInfo.postgresDsConnectionURL, steps('section_database').databaseConnectionInfo.sqlserverDsConnectionURL)))]",
             "dbUser": "[steps('section_database').databaseConnectionInfo.dbUser]",
             "dbPassword": "[steps('section_database').databaseConnectionInfo.dbPassword]"
         }

--- a/eap74-rhel8-payg-multivm/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-payg-multivm/src/main/bicep/mainTemplate.bicep
@@ -163,6 +163,7 @@ param enableCookieBasedAffinity bool = false
 @description('Boolean value indicating, if user wants to enable database connection.')
 param enableDB bool = false
 @allowed([
+  'mssqlserver'
   'postgresql'
 ])
 @description('One of the supported database types')

--- a/eap74-rhel8-payg-multivm/src/main/bicep/modules/_deployment-scripts/_ds-jbossEAPSetup.bicep
+++ b/eap74-rhel8-payg-multivm/src/main/bicep/modules/_deployment-scripts/_ds-jbossEAPSetup.bicep
@@ -82,6 +82,7 @@ param nicName string
 @description('Boolean value indicating, if user wants to enable database connection.')
 param enableDB bool = false
 @allowed([
+  'mssqlserver'
   'postgresql'
 ])
 @description('One of the supported database types')

--- a/eap74-rhel8-payg-multivm/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/create-ds-mssqlserver.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+set -Eeuo pipefail
+
+log() {
+    while IFS= read -r line; do
+        printf '%s %s\n' "$(date "+%Y-%m-%d %H:%M:%S")" "$line" >> /var/log/jbosseap.install.log
+    done
+}
+
+# Parameters
+eapRootPath=$1                                      # Root path of JBoss EAP
+jdbcDataSourceName=$2                               # JDBC Datasource name
+jdbcDSJNDIName=$(echo "${3}" | base64 -d)           # JDBC Datasource JNDI name
+dsConnectionString=$(echo "${4}" | base64 -d)       # JDBC Datasource connection String
+databaseUser=$(echo "${5}" | base64 -d)             # Database username
+databasePassword=$(echo "${6}" | base64 -d)         # Database user password
+isManagedDomain=$7                                  # true if the server is in a managed domain, false otherwise
+isSlaveServer=$8                                    # true if it's a slave server of a managed domain, false otherwise
+
+# Create JDBC driver and module directory
+jdbcDriverModuleDirectory="$eapRootPath"/modules/com/microsoft/sqlserver/main
+mkdir -p "$jdbcDriverModuleDirectory"
+
+# Download JDBC driver
+version=11.2.1.jre8
+jdbcDriverName=mssql-jdbc-${version}.jar
+curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${version}/${jdbcDriverName}
+
+# Create module for JDBC driver
+jdbcDriverModule=module.xml
+cat <<EOF >${jdbcDriverModule}
+<?xml version="1.0" ?>
+<module xmlns="urn:jboss:module:1.1" name="com.microsoft.sqlserver">
+  <resources>
+    <resource-root path="${jdbcDriverName}"/>
+  </resources>
+  <dependencies>
+    <module name="javaee.api"/>
+    <module name="sun.jdk"/>
+    <module name="ibm.jdk"/>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+    <module name="javax.xml.bind.api"/>
+  </dependencies>
+</module>
+EOF
+chmod 644 $jdbcDriverModule
+mv $jdbcDriverModule $jdbcDriverModuleDirectory/$jdbcDriverModule
+
+if [ $isManagedDomain == "false" ]; then
+    # Register JDBC driver
+    sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \
+    "/subsystem=datasources/jdbc-driver=sqlserver:add(driver-name=sqlserver,driver-module-name=com.microsoft.sqlserver,driver-xa-datasource-class-name=com.microsoft.sqlserver.jdbc.SQLServerXADataSource)" | log
+
+    # Create data source
+    echo "data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=*** --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter" | log
+    sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \
+    "data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=${databasePassword} --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter"
+elif [ $isSlaveServer == "false" ]; then
+    # Register JDBC driver
+    sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --controller=$(hostname -I) --echo-command \
+    "/profile=ha/subsystem=datasources/jdbc-driver=sqlserver:add(driver-name=sqlserver,driver-module-name=com.microsoft.sqlserver,driver-xa-datasource-class-name=com.microsoft.sqlserver.jdbc.SQLServerXADataSource)" | log
+
+    # Create data source
+    echo "data-source add --profile=ha --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=*** --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter" | log
+    sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --controller=$(hostname -I) --echo-command \
+    "data-source add --driver-name=sqlserver --profile=ha --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=${databasePassword} --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter"
+fi

--- a/eap74-rhel8-payg-multivm/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/create-ds-mssqlserver.sh
@@ -22,9 +22,9 @@ jdbcDriverModuleDirectory="$eapRootPath"/modules/com/microsoft/sqlserver/main
 mkdir -p "$jdbcDriverModuleDirectory"
 
 # Download JDBC driver
-version=11.2.1.jre8
-jdbcDriverName=mssql-jdbc-${version}.jar
-curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${version}/${jdbcDriverName}
+jdbcDriverVersion=11.2.1.jre8
+jdbcDriverName=mssql-jdbc-${jdbcDriverVersion}.jar
+curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${jdbcDriverVersion}/${jdbcDriverName}
 
 # Create module for JDBC driver
 jdbcDriverModule=module.xml

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
@@ -9,6 +9,7 @@ SCRIPT_LOCATION=${ARTIFACTS_LOCATION}${PATH_TO_SCRIPT}
 
 # Script URIs for creating data source connection
 postgresqlDSScriptUri="${SCRIPT_LOCATION}/create-ds-postgresql.sh"
+mssqlserverDSScriptUri="${SCRIPT_LOCATION}/create-ds-mssqlserver.sh"
 
 if [ "${CONFIGURATION_MODE}" != "managed-domain" ]; then
     # Configure standalone host
@@ -25,7 +26,7 @@ if [ "${CONFIGURATION_MODE}" != "managed-domain" ]; then
         --vm-name ${VM_NAME_PREFIX}${i} \
         --publisher Microsoft.Azure.Extensions \
         --version 2.0 \
-        --settings "{\"fileUris\": [\"${SCRIPT_LOCATION}/jbosseap-setup-standalone.sh\", \"${postgresqlDSScriptUri}\"]}" \
+        --settings "{\"fileUris\": [\"${SCRIPT_LOCATION}/jbosseap-setup-standalone.sh\", \"${postgresqlDSScriptUri}\", \"${mssqlserverDSScriptUri}\"]}" \
         --protected-settings "{\"commandToExecute\":\"sh jbosseap-setup-standalone.sh -a ${ARTIFACTS_LOCATION} -t ${ARTIFACTS_LOCATION_SAS_TOKEN} -p ${PATH_TO_FILE} -f ${FILE_TO_DOWNLOAD} ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${JDK_VERSION} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY_BASE64} ${SATELLITE_ORG_NAME_BASE64} ${SATELLITE_VM_FQDN} ${ENABLE_DB} ${DATABASE_TYPE} ${JDBC_DATA_SOURCE_JNDI_NAME_BASE64} ${DS_CONNECTION_URL_BASE64} ${DB_USER_BASE64} ${DB_PASSWORD_BASE64}\"}"
         if [ $? != 0 ] ; then echo "Failed to configure standalone host ${VM_NAME_PREFIX}${i}"; exit 1; fi
         echo "standalone ${VM_NAME_PREFIX}${i} extension execution completed"
@@ -56,7 +57,7 @@ else
         --vm-name ${ADMIN_VM_NAME} \
         --publisher Microsoft.Azure.Extensions \
         --version 2.0 \
-        --settings "{\"fileUris\": [\"${SCRIPT_LOCATION}/jbosseap-setup-master.sh\", \"${enableElytronSe17DomainCliUri}\", \"${postgresqlDSScriptUri}\"]}" \
+        --settings "{\"fileUris\": [\"${SCRIPT_LOCATION}/jbosseap-setup-master.sh\", \"${enableElytronSe17DomainCliUri}\", \"${postgresqlDSScriptUri}\", \"${mssqlserverDSScriptUri}\"]}" \
         --protected-settings "{\"commandToExecute\":\"sh jbosseap-setup-master.sh ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${JDK_VERSION} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${privateEndpointIp} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY_BASE64} ${SATELLITE_ORG_NAME_BASE64} ${SATELLITE_VM_FQDN} ${ENABLE_DB} ${DATABASE_TYPE} ${JDBC_DATA_SOURCE_JNDI_NAME_BASE64} ${DS_CONNECTION_URL_BASE64} ${DB_USER_BASE64} ${DB_PASSWORD_BASE64}\"}"
         # error exception
         if [ $? != 0 ] ; then echo "Failed to configure domain controller host: ${ADMIN_VM_NAME}"; exit 1; fi
@@ -74,7 +75,7 @@ else
         --vm-name ${VM_NAME_PREFIX}${i} \
         --publisher Microsoft.Azure.Extensions \
         --version 2.0 \
-        --settings "{\"fileUris\": [\"${SCRIPT_LOCATION}/jbosseap-setup-slave.sh\", \"${enableElytronSe17DomainCliUri}\", \"${postgresqlDSScriptUri}\"]}" \
+        --settings "{\"fileUris\": [\"${SCRIPT_LOCATION}/jbosseap-setup-slave.sh\", \"${enableElytronSe17DomainCliUri}\", \"${postgresqlDSScriptUri}\", \"${mssqlserverDSScriptUri}\"]}" \
         --protected-settings "{\"commandToExecute\":\"sh jbosseap-setup-slave.sh ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${JDK_VERSION} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${privateEndpointIp} ${DOMAIN_CONTROLLER_PRIVATE_IP} ${NUMBER_OF_SERVER_INSTANCE} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY_BASE64} ${SATELLITE_ORG_NAME_BASE64} ${SATELLITE_VM_FQDN} ${ENABLE_DB} ${DATABASE_TYPE} ${JDBC_DATA_SOURCE_JNDI_NAME_BASE64} ${DS_CONNECTION_URL_BASE64} ${DB_USER_BASE64} ${DB_PASSWORD_BASE64}\"}"
         if [ $? != 0 ] ; then echo "Failed to configure domain slave host: ${VM_NAME_PREFIX}${i}"; exit 1; fi
         echo "Slave ${VM_NAME_PREFIX}${i} extension execution completed"

--- a/eap74-rhel8-payg-vmss/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-vmss/src/main/arm/createUiDefinition.json
@@ -690,9 +690,13 @@
                                 "type": "Microsoft.Common.DropDown",
                                 "label": "Choose database type",
                                 "toolTip": "Choose database type",
-                                "defaultValue": "PostgreSQL",
+                                "defaultValue": "Microsoft SQL Server",
                                 "constraints": {
                                     "allowedValues": [
+                                        {
+                                            "label": "Microsoft SQL Server",
+                                            "value": "mssqlserver"
+                                        },
                                         {
                                             "label": "PostgreSQL",
                                             "value": "postgresql"
@@ -714,6 +718,45 @@
                                     "validationMessage": "The value must be 1-30 characters long and must only contain letters, numbers, hyphens (-), underscores (_), periods (.) and slashes (/)."
                                 },
                                 "visible": true
+                            },
+                            {
+                                "name": "sqlserverDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:sqlserver://&lt;host&gt;:&lt;port&gt;;database=&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:sqlserver:\/\/([^\/]+):([0-9]+);database=([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'mssqlserver')]"
+                            },
+                            {
+                                "name": "oracleDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:oracle:thin:@&lt;host&gt;:&lt;port&gt;/&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:oracle:thin:@([^\/]+):([0-9]+)\/([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'oracle')]"
+                            },
+                            {
+                                "name": "mysqlDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:mysql://&lt;host&gt;:&lt;port&gt;/&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:mysql:\/\/([^\/]+):([0-9]+)\/([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql')]"
                             },
                             {
                                 "name": "postgresDsConnectionURL",
@@ -807,7 +850,7 @@
             "enableDB": "[bool(steps('section_database').enableDB)]",
             "databaseType": "[steps('section_database').databaseConnectionInfo.databaseType]",
             "jdbcDataSourceJNDIName": "[steps('section_database').databaseConnectionInfo.jdbcDataSourceJNDIName]",
-            "dsConnectionURL": "[steps('section_database').databaseConnectionInfo.postgresDsConnectionURL]",
+            "dsConnectionURL": "[if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'oracle'), steps('section_database').databaseConnectionInfo.oracleDsConnectionURL, if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql'), steps('section_database').databaseConnectionInfo.mysqlDsConnectionURL, if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'postgresql'), steps('section_database').databaseConnectionInfo.postgresDsConnectionURL, steps('section_database').databaseConnectionInfo.sqlserverDsConnectionURL)))]",
             "dbUser": "[steps('section_database').databaseConnectionInfo.dbUser]",
             "dbPassword": "[steps('section_database').databaseConnectionInfo.dbPassword]"
         }

--- a/eap74-rhel8-payg-vmss/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-payg-vmss/src/main/bicep/mainTemplate.bicep
@@ -154,6 +154,7 @@ param enableCookieBasedAffinity bool = false
 @description('Boolean value indicating, if user wants to enable database connection.')
 param enableDB bool = false
 @allowed([
+  'mssqlserver'
   'postgresql'
 ])
 @description('One of the supported database types')
@@ -488,6 +489,7 @@ resource vmssInstanceName 'Microsoft.Compute/virtualMachineScaleSets@2022-08-01'
                 fileUris: [
                   uri(artifactsLocation, 'scripts/jbosseap-setup-redhat.sh${artifactsLocationSasToken}')
                   uri(artifactsLocation, 'scripts/create-ds-postgresql.sh${artifactsLocationSasToken}')
+                  uri(artifactsLocation, 'scripts/create-ds-mssqlserver.sh${artifactsLocationSasToken}')
                 ]
               }
               protectedSettings: {

--- a/eap74-rhel8-payg-vmss/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap74-rhel8-payg-vmss/src/main/scripts/create-ds-mssqlserver.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -Eeuo pipefail
+
+log() {
+    while IFS= read -r line; do
+        printf '%s %s\n' "$(date "+%Y-%m-%d %H:%M:%S")" "$line" >> /var/log/jbosseap.install.log
+    done
+}
+
+# Parameters
+eapRootPath=$1                                      # Root path of JBoss EAP
+jdbcDataSourceName=$2                               # JDBC Datasource name
+jdbcDSJNDIName=$(echo "${3}" | base64 -d)           # JDBC Datasource JNDI name
+dsConnectionString=$(echo "${4}" | base64 -d)       # JDBC Datasource connection String
+databaseUser=$(echo "${5}" | base64 -d)             # Database username
+databasePassword=$(echo "${6}" | base64 -d)         # Database user password
+
+# Create JDBC driver and module directory
+jdbcDriverModuleDirectory="$eapRootPath"/modules/com/microsoft/sqlserver/main
+mkdir -p "$jdbcDriverModuleDirectory"
+
+# Download JDBC driver
+version=11.2.1.jre8
+jdbcDriverName=mssql-jdbc-${version}.jar
+curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${version}/${jdbcDriverName}
+
+# Create module for JDBC driver
+jdbcDriverModule=module.xml
+cat <<EOF >${jdbcDriverModule}
+<?xml version="1.0" ?>
+<module xmlns="urn:jboss:module:1.1" name="com.microsoft.sqlserver">
+  <resources>
+    <resource-root path="${jdbcDriverName}"/>
+  </resources>
+  <dependencies>
+    <module name="javaee.api"/>
+    <module name="sun.jdk"/>
+    <module name="ibm.jdk"/>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+    <module name="javax.xml.bind.api"/>
+  </dependencies>
+</module>
+EOF
+chmod 644 $jdbcDriverModule
+mv $jdbcDriverModule $jdbcDriverModuleDirectory/$jdbcDriverModule
+
+# Register JDBC driver
+sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \
+"/subsystem=datasources/jdbc-driver=sqlserver:add(driver-name=sqlserver,driver-module-name=com.microsoft.sqlserver,driver-xa-datasource-class-name=com.microsoft.sqlserver.jdbc.SQLServerXADataSource)" | log
+
+# Create data source
+echo "data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=*** --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter" | log
+sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \
+"data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=${databasePassword} --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter"

--- a/eap74-rhel8-payg-vmss/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap74-rhel8-payg-vmss/src/main/scripts/create-ds-mssqlserver.sh
@@ -20,9 +20,9 @@ jdbcDriverModuleDirectory="$eapRootPath"/modules/com/microsoft/sqlserver/main
 mkdir -p "$jdbcDriverModuleDirectory"
 
 # Download JDBC driver
-version=11.2.1.jre8
-jdbcDriverName=mssql-jdbc-${version}.jar
-curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${version}/${jdbcDriverName}
+jdbcDriverVersion=11.2.1.jre8
+jdbcDriverName=mssql-jdbc-${jdbcDriverVersion}.jar
+curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${jdbcDriverVersion}/${jdbcDriverName}
 
 # Create module for JDBC driver
 jdbcDriverModule=module.xml

--- a/eap74-rhel8-payg/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg/src/main/arm/createUiDefinition.json
@@ -566,9 +566,13 @@
                                 "type": "Microsoft.Common.DropDown",
                                 "label": "Choose database type",
                                 "toolTip": "Choose database type",
-                                "defaultValue": "PostgreSQL",
+                                "defaultValue": "Microsoft SQL Server",
                                 "constraints": {
                                     "allowedValues": [
+                                        {
+                                            "label": "Microsoft SQL Server",
+                                            "value": "mssqlserver"
+                                        },
                                         {
                                             "label": "PostgreSQL",
                                             "value": "postgresql"
@@ -590,6 +594,45 @@
                                     "validationMessage": "The value must be 1-30 characters long and must only contain letters, numbers, hyphens (-), underscores (_), periods (.) and slashes (/)."
                                 },
                                 "visible": true
+                            },
+                            {
+                                "name": "sqlserverDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:sqlserver://&lt;host&gt;:&lt;port&gt;;database=&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:sqlserver:\/\/([^\/]+):([0-9]+);database=([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'mssqlserver')]"
+                            },
+                            {
+                                "name": "oracleDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:oracle:thin:@&lt;host&gt;:&lt;port&gt;/&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:oracle:thin:@([^\/]+):([0-9]+)\/([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'oracle')]"
+                            },
+                            {
+                                "name": "mysqlDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:mysql://&lt;host&gt;:&lt;port&gt;/&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:mysql:\/\/([^\/]+):([0-9]+)\/([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql')]"
                             },
                             {
                                 "name": "postgresDsConnectionURL",
@@ -676,7 +719,7 @@
             "enableDB": "[bool(steps('section_database').enableDB)]",
             "databaseType": "[steps('section_database').databaseConnectionInfo.databaseType]",
             "jdbcDataSourceJNDIName": "[steps('section_database').databaseConnectionInfo.jdbcDataSourceJNDIName]",
-            "dsConnectionURL": "[steps('section_database').databaseConnectionInfo.postgresDsConnectionURL]",
+            "dsConnectionURL": "[if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'oracle'), steps('section_database').databaseConnectionInfo.oracleDsConnectionURL, if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql'), steps('section_database').databaseConnectionInfo.mysqlDsConnectionURL, if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'postgresql'), steps('section_database').databaseConnectionInfo.postgresDsConnectionURL, steps('section_database').databaseConnectionInfo.sqlserverDsConnectionURL)))]",
             "dbUser": "[steps('section_database').databaseConnectionInfo.dbUser]",
             "dbPassword": "[steps('section_database').databaseConnectionInfo.dbPassword]"
         }

--- a/eap74-rhel8-payg/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-payg/src/main/bicep/mainTemplate.bicep
@@ -110,6 +110,7 @@ param satelliteFqdn string = newGuid()
 @description('Boolean value indicating, if user wants to enable database connection.')
 param enableDB bool = false
 @allowed([
+  'mssqlserver'
   'postgresql'
 ])
 @description('One of the supported database types')
@@ -303,6 +304,7 @@ resource vmName_jbosseap_setup_extension 'Microsoft.Compute/virtualMachines/exte
       fileUris: [
         uri(artifactsLocation, 'scripts/jbosseap-setup-redhat.sh${artifactsLocationSasToken}')
         uri(artifactsLocation, 'scripts/create-ds-postgresql.sh${artifactsLocationSasToken}')
+        uri(artifactsLocation, 'scripts/create-ds-mssqlserver.sh${artifactsLocationSasToken}')
       ]
     }
     protectedSettings: {

--- a/eap74-rhel8-payg/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap74-rhel8-payg/src/main/scripts/create-ds-mssqlserver.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -Eeuo pipefail
+
+log() {
+    while IFS= read -r line; do
+        printf '%s %s\n' "$(date "+%Y-%m-%d %H:%M:%S")" "$line" >> /var/log/jbosseap.install.log
+    done
+}
+
+# Parameters
+eapRootPath=$1                                      # Root path of JBoss EAP
+jdbcDataSourceName=$2                               # JDBC Datasource name
+jdbcDSJNDIName=$(echo "${3}" | base64 -d)           # JDBC Datasource JNDI name
+dsConnectionString=$(echo "${4}" | base64 -d)       # JDBC Datasource connection String
+databaseUser=$(echo "${5}" | base64 -d)             # Database username
+databasePassword=$(echo "${6}" | base64 -d)         # Database user password
+
+# Create JDBC driver and module directory
+jdbcDriverModuleDirectory="$eapRootPath"/modules/com/microsoft/sqlserver/main
+mkdir -p "$jdbcDriverModuleDirectory"
+
+# Download JDBC driver
+version=11.2.1.jre8
+jdbcDriverName=mssql-jdbc-${version}.jar
+curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${version}/${jdbcDriverName}
+
+# Create module for JDBC driver
+jdbcDriverModule=module.xml
+cat <<EOF >${jdbcDriverModule}
+<?xml version="1.0" ?>
+<module xmlns="urn:jboss:module:1.1" name="com.microsoft.sqlserver">
+  <resources>
+    <resource-root path="${jdbcDriverName}"/>
+  </resources>
+  <dependencies>
+    <module name="javaee.api"/>
+    <module name="sun.jdk"/>
+    <module name="ibm.jdk"/>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+    <module name="javax.xml.bind.api"/>
+  </dependencies>
+</module>
+EOF
+chmod 644 $jdbcDriverModule
+mv $jdbcDriverModule $jdbcDriverModuleDirectory/$jdbcDriverModule
+
+# Register JDBC driver
+sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \
+"/subsystem=datasources/jdbc-driver=sqlserver:add(driver-name=sqlserver,driver-module-name=com.microsoft.sqlserver,driver-xa-datasource-class-name=com.microsoft.sqlserver.jdbc.SQLServerXADataSource)" | log
+
+# Create data source
+echo "data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=*** --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter" | log
+sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \
+"data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --user-name=${databaseUser} --password=${databasePassword} --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter"

--- a/eap74-rhel8-payg/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap74-rhel8-payg/src/main/scripts/create-ds-mssqlserver.sh
@@ -20,9 +20,9 @@ jdbcDriverModuleDirectory="$eapRootPath"/modules/com/microsoft/sqlserver/main
 mkdir -p "$jdbcDriverModuleDirectory"
 
 # Download JDBC driver
-version=11.2.1.jre8
-jdbcDriverName=mssql-jdbc-${version}.jar
-curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${version}/${jdbcDriverName}
+jdbcDriverVersion=11.2.1.jre8
+jdbcDriverName=mssql-jdbc-${jdbcDriverVersion}.jar
+curl --retry 5 -Lo ${jdbcDriverModuleDirectory}/${jdbcDriverName} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/${jdbcDriverVersion}/${jdbcDriverName}
 
 # Create module for JDBC driver
 jdbcDriverModule=module.xml


### PR DESCRIPTION
## Description

The PR is to resolve the following issues:
* Resolve #177 

## Change summary

For 6 JBoss EAP on VMs offers (standalone/vmss/multivm * payg/byos):
* Add a new database type **Microsoft SQL Server** to blade **Database** in UI.
* Update template to accept database connection for **Microsoft SQL Server**.
* Add new scripts to register **Microsoft SQL Server** JDBC driver and data source.
* Update the validation pipelines to support **Microsoft SQL Server** connection per user inputs.

## Testing

Verified the following 6 test cases with validation pipelines:

|License |Infrastructure |Database connection |Workflow |
|---|---|---|---|
|PAYG |Standalone |Microsoft SQL Server |[Validate payg-single offer](https://github.com/majguo/rhel-jboss-templates/actions/runs/4410687543) |
|PAYG |VMSS |Microsoft SQL Server |[Validate payg-vmss offer](https://github.com/majguo/rhel-jboss-templates/actions/runs/4410690623) |
|PAYG |Cluster |Microsoft SQL Server |[Validate payg-multivm offer](https://github.com/majguo/rhel-jboss-templates/actions/runs/4410689264) |
|BYOS |Standalone |Microsoft SQL Server |[Validate byos-single offer](https://github.com/majguo/rhel-jboss-templates/actions/runs/4410683924) |
|BYOS |VMSS |Microsoft SQL Server |[Validate byos-vmss offer](https://github.com/majguo/rhel-jboss-templates/actions/runs/4410686209) |
|BYOS |Cluster |Microsoft SQL Server |[Validate byos-multivm offer](https://github.com/majguo/rhel-jboss-templates/actions/runs/4410685195) |

## UI changes review

Reviewer can preview the UI changes using the **Create UI Definition Sandbox**:

- Open [Create UI Definition Sandbox](https://portal.azure.com/?feature.customPortal=false#blade/Microsoft_Azure_CreateUIDef/SandboxBlade) in a new tab of browser.
- Open UI source code [createUiDefinition.json](https://raw.githubusercontent.com/majguo/rhel-jboss-templates/db-support-mssqlserver/eap74-rhel8-payg-vmss/src/main/arm/createUiDefinition.json) in a new tab of the browser.
- Replace the content of work area in **Create UI Definition Sandbox** with the content of **UI source code `createUiDefinition.json`**.
- Click **Preview** at the left-bottom of **Create UI Definition Sandbox**.
- The major UI changes include the addition of new database type **Microsoft SQL Server** in `Database` tab.

Here is the screenshot of UI changes overview:
![image](https://user-images.githubusercontent.com/10357495/225188831-7697b01e-928b-4f76-a997-c2b68d1f36b0.png)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>