### PR TITLE
Update jndi to `jdbc/JavaEECafeDB` in sample app

### DIFF
--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -367,12 +367,12 @@ jobs:
                     --template-file rhel-jboss-templates/eap74-rhel8-byos-multivm/mainTemplate.json
             - name: Build javaee cafe
               run: |
-                if ${{ env.enableDB == 'true' }}; then
-                  sed -i "s/java:jboss\/datasources\/ExampleDS/jdbc\/JavaEECafeDB/g" rhel-jboss-templates/eap-coffee-app/src/main/resources/META-INF/persistence.xml
+                if ${{ env.enableDB != 'true' }}; then
+                  sed -i "s/jdbc\/JavaEECafeDB/java:jboss\/datasources\/ExampleDS/g" rhel-jboss-templates/eap-coffee-app/src/main/resources/META-INF/persistence.xml
                 fi
                 mvn clean install --file rhel-jboss-templates/eap-coffee-app/pom.xml
-                if ${{ env.enableDB == 'true' }}; then
-                  sed -i "s/jdbc\/JavaEECafeDB/java:jboss\/datasources\/ExampleDS/g" rhel-jboss-templates/eap-coffee-app/src/main/resources/META-INF/persistence.xml
+                if ${{ env.enableDB != 'true' }}; then
+                  sed -i "s/java:jboss\/datasources\/ExampleDS/jdbc\/JavaEECafeDB/g" rhel-jboss-templates/eap-coffee-app/src/main/resources/META-INF/persistence.xml
                 fi
             - name: Create a container and uploading cafe app
               id: upload_cafe_app

--- a/.github/workflows/validate-payg-multivm.yaml
+++ b/.github/workflows/validate-payg-multivm.yaml
@@ -355,12 +355,12 @@ jobs:
                     --template-file rhel-jboss-templates/eap74-rhel8-payg-multivm/mainTemplate.json
             - name: Build javaee cafe
               run: |
-                if ${{ env.enableDB == 'true' }}; then
-                  sed -i "s/java:jboss\/datasources\/ExampleDS/jdbc\/JavaEECafeDB/g" rhel-jboss-templates/eap-coffee-app/src/main/resources/META-INF/persistence.xml
+                if ${{ env.enableDB != 'true' }}; then
+                  sed -i "s/jdbc\/JavaEECafeDB/java:jboss\/datasources\/ExampleDS/g" rhel-jboss-templates/eap-coffee-app/src/main/resources/META-INF/persistence.xml
                 fi
                 mvn clean install --file rhel-jboss-templates/eap-coffee-app/pom.xml
-                if ${{ env.enableDB == 'true' }}; then
-                  sed -i "s/jdbc\/JavaEECafeDB/java:jboss\/datasources\/ExampleDS/g" rhel-jboss-templates/eap-coffee-app/src/main/resources/META-INF/persistence.xml
+                if ${{ env.enableDB != 'true' }}; then
+                  sed -i "s/java:jboss\/datasources\/ExampleDS/jdbc\/JavaEECafeDB/g" rhel-jboss-templates/eap-coffee-app/src/main/resources/META-INF/persistence.xml
                 fi
             - name: Create a container and uploading cafe app
               id: upload_cafe_app

--- a/eap-coffee-app/src/main/resources/META-INF/persistence.xml
+++ b/eap-coffee-app/src/main/resources/META-INF/persistence.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
     <persistence-unit name="coffees">
-        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <jta-data-source>jdbc/JavaEECafeDB</jta-data-source>
         <properties>
             <property
                 name="javax.persistence.schema-generation.database.action"


### PR DESCRIPTION
To simplify the JBoss EAP on VMs guidance with DB connection (manual step or quick start), update jndi from `java:jboss/datasources/ExampleDS` (connecting to the default `H2` data source in JBoss EAP server) to `jdbc/JavaEECafeDB` (connecting to an external data source that should be manually configured by user) in sample app so user don't need to manually modify the value of JDNI.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>