### PR TITLE
Fix regression issue for creating data source in domain mode cluster

### DIFF
--- a/eap74-rhel8-byos-multivm/pom.xml
+++ b/eap74-rhel8-byos-multivm/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-byos-multivm</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/eap74-rhel8-byos-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-byos-multivm/src/main/arm/createUiDefinition.json
@@ -779,8 +779,8 @@
                                 "defaultValue": "",
                                 "constraints": {
                                     "required": true,
-                                    "regex": "^[a-zA-Z0-9./_-]{1,30}$",
-                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters, numbers, hyphens (-), underscores (_), periods (.) and slashes (/)."
+                                    "regex": "^[a-zA-Z0-9:./_-]+$",
+                                    "validationMessage": "The value must only contain letters, numbers, colon (:), hyphens (-), underscores (_), periods (.) and slashes (/)."
                                 },
                                 "visible": true
                             },

--- a/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-setup-master-ds.sh
+++ b/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-setup-master-ds.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -Eeuo pipefail
+
+log() {
+    while IFS= read -r line; do
+        printf '%s %s\n' "$(date "+%Y-%m-%d %H:%M:%S")" "$line" >> /var/log/jbosseap.install.log
+    done
+}
+
+dbType=${1}
+jdbcDataSourceName=${2}
+jdbcDSJNDIName=${3}
+dsConnectionString=${4}
+databaseUser=${5}
+databasePassword=${6}
+
+# Load environment variables where EAP_HOME is defined
+source /etc/profile.d/eap_env.sh
+
+# Configure JDBC driver and data source
+echo "Start to configure JDBC driver and data source" | log
+./create-ds-${dbType}.sh $EAP_HOME/wildfly "$jdbcDataSourceName" "$jdbcDSJNDIName" "$dsConnectionString" "$databaseUser" "$databasePassword" true false
+echo "Complete to configure JDBC driver and data source" | log

--- a/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-setup-master.sh
+++ b/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-setup-master.sh
@@ -280,13 +280,5 @@ if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP management user configuration F
 # Seeing a race condition timing error so sleep to delay
 sleep 20
 
-# Configure JDBC driver and data source
-if [ "$enableDB" == "True" ]; then
-    echo "Start to configure JDBC driver and data source" | log
-    jdbcDataSourceName=dataSource-$dbType
-    ./create-ds-${dbType}.sh $EAP_HOME/wildfly "$jdbcDataSourceName" "$jdbcDSJNDIName" "$dsConnectionString" "$databaseUser" "$databasePassword" true false
-    echo "Complete to configure JDBC driver and data source" | log
-fi
-
 echo "Red Hat JBoss EAP Cluster Intallation End " | log; flag=${PIPESTATUS[0]}
 /bin/date +%H:%M:%S | log

--- a/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-setup-master.sh
+++ b/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-setup-master.sh
@@ -75,12 +75,6 @@ SATELLITE_ACTIVATION_KEY=$(echo $SATELLITE_ACTIVATION_KEY_BASE64 | base64 -d)
 SATELLITE_ORG_NAME_BASE64=${14}
 SATELLITE_ORG_NAME=$(echo $SATELLITE_ORG_NAME_BASE64 | base64 -d)
 SATELLITE_VM_FQDN=${15}
-enableDB=${16}
-dbType=${17}
-jdbcDSJNDIName=${18}
-dsConnectionString=${19}
-databaseUser=${20}
-databasePassword=${21}
 
 MOUNT_POINT_PATH=/mnt/jbossshare
 HOST_VM_IP=$(hostname -I)

--- a/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-setup-slave.sh
+++ b/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-setup-slave.sh
@@ -289,36 +289,6 @@ if [ "$enableDB" == "True" ]; then
     jdbcDataSourceName=dataSource-$dbType
     ./create-ds-${dbType}.sh $EAP_HOME/wildfly "$jdbcDataSourceName" "$jdbcDSJNDIName" "$dsConnectionString" "$databaseUser" "$databasePassword" true true
     echo "Complete to install JDBC driver module" | log
-
-    # Reload servers
-    echo "Reload servers" | log
-    for ((i = 0; i < NUMBER_OF_SERVER_INSTANCE; i++)); do
-        sudo -u jboss $EAP_HOME/wildfly/bin/jboss-cli.sh --connect --controller=${DOMAIN_CONTROLLER_PRIVATE_IP} --user=${JBOSS_EAP_USER} --password=${JBOSS_EAP_PASSWORD} \
-            "/host=${HOST_VM_NAME_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/:reload"
-
-        sudo -u jboss $EAP_HOME/wildfly/bin/jboss-cli.sh --connect --controller=${DOMAIN_CONTROLLER_PRIVATE_IP} --user=${JBOSS_EAP_USER} --password=${JBOSS_EAP_PASSWORD} \
-            "/host=${HOST_VM_NAME_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/:read-attribute(name=server-state)"
-        while [ $? -ne 0 ]
-        do
-            echo "${HOST_VM_NAME_LOWERCASES}-server${i} is starting..." | log
-            sleep 5
-            sudo -u jboss $EAP_HOME/wildfly/bin/jboss-cli.sh --connect --controller=${DOMAIN_CONTROLLER_PRIVATE_IP} --user=${JBOSS_EAP_USER} --password=${JBOSS_EAP_PASSWORD} \
-                "/host=${HOST_VM_NAME_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/:read-attribute(name=server-state)"
-        done
-    done
-    echo "All servers are running now" | log
-
-    # Test connection for the created data source
-    echo "Start to test data source connection" | log
-    for ((i = 0; i < NUMBER_OF_SERVER_INSTANCE; i++)); do
-        sudo -u jboss $EAP_HOME/wildfly/bin/jboss-cli.sh --connect --controller=${DOMAIN_CONTROLLER_PRIVATE_IP} --user=${JBOSS_EAP_USER} --password=${JBOSS_EAP_PASSWORD} \
-            "/host=${HOST_VM_NAME_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/subsystem=datasources/data-source=$jdbcDataSourceName:test-connection-in-pool" | log; flag=${PIPESTATUS[0]}
-        if [ $flag != 0 ]; then 
-            echo "ERROR! Test data source connection failed." >&2 log
-            exit $flag
-        fi
-    done   
-    echo "Complete to test data source connection" | log
 fi
 
 echo "Red Hat JBoss EAP Cluster Intallation End " | log; flag=${PIPESTATUS[0]}

--- a/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-test-slave-ds.sh
+++ b/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-test-slave-ds.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+log() {
+    while IFS= read -r line; do
+        printf '%s %s\n' "$(date "+%Y-%m-%d %H:%M:%S")" "$line" >> /var/log/jbosseap.install.log
+    done
+}
+
+JBOSS_EAP_USER=${1}
+JBOSS_EAP_PASSWORD_BASE64=${2}
+JBOSS_EAP_PASSWORD=$(echo $JBOSS_EAP_PASSWORD_BASE64 | base64 -d)
+DOMAIN_CONTROLLER_PRIVATE_IP=${3}
+NUMBER_OF_SERVER_INSTANCE=${4}
+jdbcDataSourceName=${5}
+
+HOST_VM_NAME=$(hostname)
+HOST_VM_NAME_LOWERCASES=$(echo "${HOST_VM_NAME,,}")
+FQDN=$(hostname -A)
+FQDN_LOWERCASES=$(echo "${FQDN,,}")
+
+# Load environment variables where EAP_HOME is defined
+source /etc/profile.d/eap_env.sh
+
+# Test connection for the created data source
+echo "Start to test data source connection" | log
+for ((i = 0; i < NUMBER_OF_SERVER_INSTANCE; i++)); do
+    sudo -u jboss $EAP_HOME/wildfly/bin/jboss-cli.sh --connect --controller=${DOMAIN_CONTROLLER_PRIVATE_IP} --user=${JBOSS_EAP_USER} --password=${JBOSS_EAP_PASSWORD} \
+        "/host=${HOST_VM_NAME_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/subsystem=datasources/data-source=$jdbcDataSourceName:test-connection-in-pool" | log; flag=${PIPESTATUS[0]}
+    if [ $flag != 0 ]; then
+        # Retry data source connection test using FQDN of the worker node
+        sudo -u jboss $EAP_HOME/wildfly/bin/jboss-cli.sh --connect --controller=${DOMAIN_CONTROLLER_PRIVATE_IP} --user=${JBOSS_EAP_USER} --password=${JBOSS_EAP_PASSWORD} \
+            "/host=${FQDN_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/subsystem=datasources/data-source=$jdbcDataSourceName:test-connection-in-pool" | log; flag=${PIPESTATUS[0]}
+        if [ $flag != 0 ]; then 
+            echo "ERROR! Test data source connection failed." >&2 log
+            exit $flag
+        fi
+    fi
+done
+echo "Complete to test data source connection" | log

--- a/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-test-slave-ds.sh
+++ b/eap74-rhel8-byos-multivm/src/main/scripts/jbosseap-test-slave-ds.sh
@@ -13,23 +13,23 @@ DOMAIN_CONTROLLER_PRIVATE_IP=${3}
 NUMBER_OF_SERVER_INSTANCE=${4}
 jdbcDataSourceName=${5}
 
-HOST_VM_NAME=$(hostname)
-HOST_VM_NAME_LOWERCASES=$(echo "${HOST_VM_NAME,,}")
 FQDN=$(hostname -A)
 FQDN_LOWERCASES=$(echo "${FQDN,,}")
+HOST_VM_NAME=$(hostname)
+HOST_VM_NAME_LOWERCASES=$(echo "${HOST_VM_NAME,,}")
 
 # Load environment variables where EAP_HOME is defined
 source /etc/profile.d/eap_env.sh
 
-# Test connection for the created data source
 echo "Start to test data source connection" | log
 for ((i = 0; i < NUMBER_OF_SERVER_INSTANCE; i++)); do
+    # First try data source connection test using FQDN of the worker node
     sudo -u jboss $EAP_HOME/wildfly/bin/jboss-cli.sh --connect --controller=${DOMAIN_CONTROLLER_PRIVATE_IP} --user=${JBOSS_EAP_USER} --password=${JBOSS_EAP_PASSWORD} \
-        "/host=${HOST_VM_NAME_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/subsystem=datasources/data-source=$jdbcDataSourceName:test-connection-in-pool" | log; flag=${PIPESTATUS[0]}
+        "/host=${FQDN_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/subsystem=datasources/data-source=$jdbcDataSourceName:test-connection-in-pool" | log; flag=${PIPESTATUS[0]}
     if [ $flag != 0 ]; then
-        # Retry data source connection test using FQDN of the worker node
+        # Retry data source connection test using short hostname of the worker node
         sudo -u jboss $EAP_HOME/wildfly/bin/jboss-cli.sh --connect --controller=${DOMAIN_CONTROLLER_PRIVATE_IP} --user=${JBOSS_EAP_USER} --password=${JBOSS_EAP_PASSWORD} \
-            "/host=${FQDN_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/subsystem=datasources/data-source=$jdbcDataSourceName:test-connection-in-pool" | log; flag=${PIPESTATUS[0]}
+            "/host=${HOST_VM_NAME_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/subsystem=datasources/data-source=$jdbcDataSourceName:test-connection-in-pool" | log; flag=${PIPESTATUS[0]}
         if [ $flag != 0 ]; then 
             echo "ERROR! Test data source connection failed." >&2 log
             exit $flag

--- a/eap74-rhel8-byos-vmss/pom.xml
+++ b/eap74-rhel8-byos-vmss/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-byos-vmss</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/eap74-rhel8-byos-vmss/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-byos-vmss/src/main/arm/createUiDefinition.json
@@ -734,8 +734,8 @@
                                 "defaultValue": "",
                                 "constraints": {
                                     "required": true,
-                                    "regex": "^[a-zA-Z0-9./_-]{1,30}$",
-                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters, numbers, hyphens (-), underscores (_), periods (.) and slashes (/)."
+                                    "regex": "^[a-zA-Z0-9:./_-]+$",
+                                    "validationMessage": "The value must only contain letters, numbers, colon (:), hyphens (-), underscores (_), periods (.) and slashes (/)."
                                 },
                                 "visible": true
                             },

--- a/eap74-rhel8-byos/pom.xml
+++ b/eap74-rhel8-byos/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-byos</artifactId>
-    <version>1.0.11</version>
+    <version>1.0.12</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/eap74-rhel8-byos/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-byos/src/main/arm/createUiDefinition.json
@@ -610,8 +610,8 @@
                                 "defaultValue": "",
                                 "constraints": {
                                     "required": true,
-                                    "regex": "^[a-zA-Z0-9./_-]{1,30}$",
-                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters, numbers, hyphens (-), underscores (_), periods (.) and slashes (/)."
+                                    "regex": "^[a-zA-Z0-9:./_-]+$",
+                                    "validationMessage": "The value must only contain letters, numbers, colon (:), hyphens (-), underscores (_), periods (.) and slashes (/)."
                                 },
                                 "visible": true
                             },

--- a/eap74-rhel8-payg-multivm/pom.xml
+++ b/eap74-rhel8-payg-multivm/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-payg-multivm</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     

--- a/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
@@ -767,8 +767,8 @@
                                 "defaultValue": "",
                                 "constraints": {
                                     "required": true,
-                                    "regex": "^[a-zA-Z0-9./_-]{1,30}$",
-                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters, numbers, hyphens (-), underscores (_), periods (.) and slashes (/)."
+                                    "regex": "^[a-zA-Z0-9:./_-]+$",
+                                    "validationMessage": "The value must only contain letters, numbers, colon (:), hyphens (-), underscores (_), periods (.) and slashes (/)."
                                 },
                                 "visible": true
                             },

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-master-ds.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-master-ds.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -Eeuo pipefail
+
+log() {
+    while IFS= read -r line; do
+        printf '%s %s\n' "$(date "+%Y-%m-%d %H:%M:%S")" "$line" >> /var/log/jbosseap.install.log
+    done
+}
+
+dbType=${1}
+jdbcDataSourceName=${2}
+jdbcDSJNDIName=${3}
+dsConnectionString=${4}
+databaseUser=${5}
+databasePassword=${6}
+
+# Load environment variables where EAP_HOME is defined
+source /etc/profile.d/eap_env.sh
+
+# Configure JDBC driver and data source
+echo "Start to configure JDBC driver and data source" | log
+./create-ds-${dbType}.sh $EAP_HOME/wildfly "$jdbcDataSourceName" "$jdbcDSJNDIName" "$dsConnectionString" "$databaseUser" "$databasePassword" true false
+echo "Complete to configure JDBC driver and data source" | log

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-master.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-master.sh
@@ -82,12 +82,6 @@ SATELLITE_ACTIVATION_KEY=$(echo $SATELLITE_ACTIVATION_KEY_BASE64 | base64 -d)
 SATELLITE_ORG_NAME_BASE64=${13}
 SATELLITE_ORG_NAME=$(echo $SATELLITE_ORG_NAME_BASE64 | base64 -d)
 SATELLITE_VM_FQDN=${14}
-enableDB=${15}
-dbType=${16}
-jdbcDSJNDIName=${17}
-dsConnectionString=${18}
-databaseUser=${19}
-databasePassword=${20}
 
 MOUNT_POINT_PATH=/mnt/jbossshare
 HOST_VM_IP=$(hostname -I)
@@ -280,14 +274,6 @@ if [ $flag != 0 ] ; then echo  "ERROR! JBoss EAP management user configuration F
 
 # Seeing a race condition timing error so sleep to delay
 sleep 20
-
-# Configure JDBC driver and data source
-if [ "$enableDB" == "True" ]; then
-    echo "Start to configure JDBC driver and data source" | log
-    jdbcDataSourceName=dataSource-$dbType
-    ./create-ds-${dbType}.sh $EAP_HOME/wildfly "$jdbcDataSourceName" "$jdbcDSJNDIName" "$dsConnectionString" "$databaseUser" "$databasePassword" true false
-    echo "Complete to configure JDBC driver and data source" | log
-fi
 
 echo "Red Hat JBoss EAP Cluster Intallation End " | log; flag=${PIPESTATUS[0]}
 /bin/date +%H:%M:%S | log

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-redhat.sh
@@ -59,8 +59,8 @@ else
         --vm-name ${ADMIN_VM_NAME} \
         --publisher Microsoft.Azure.Extensions \
         --version 2.0 \
-        --settings "{\"fileUris\": [\"${SCRIPT_LOCATION}/jbosseap-setup-master.sh\", \"${enableElytronSe17DomainCliUri}\", \"${postgresqlDSScriptUri}\", \"${mssqlserverDSScriptUri}\", \"${oracleDSScriptUri}\", \"${mysqlDSScriptUri}\"]}" \
-        --protected-settings "{\"commandToExecute\":\"sh jbosseap-setup-master.sh ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${JDK_VERSION} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${privateEndpointIp} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY_BASE64} ${SATELLITE_ORG_NAME_BASE64} ${SATELLITE_VM_FQDN} ${ENABLE_DB} ${DATABASE_TYPE} ${JDBC_DATA_SOURCE_JNDI_NAME_BASE64} ${DS_CONNECTION_URL_BASE64} ${DB_USER_BASE64} ${DB_PASSWORD_BASE64}\"}"
+        --settings "{\"fileUris\": [\"${SCRIPT_LOCATION}/jbosseap-setup-master.sh\", \"${enableElytronSe17DomainCliUri}\"]}" \
+        --protected-settings "{\"commandToExecute\":\"sh jbosseap-setup-master.sh ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${RHSM_USER} ${RHSM_PASSWORD_BASE64} ${EAP_POOL} ${JDK_VERSION} ${STORAGE_ACCOUNT_NAME} ${CONTAINER_NAME} ${STORAGE_ACCESS_KEY} ${privateEndpointIp} ${CONNECT_SATELLITE} ${SATELLITE_ACTIVATION_KEY_BASE64} ${SATELLITE_ORG_NAME_BASE64} ${SATELLITE_VM_FQDN}\"}"
         # error exception
         if [ $? != 0 ] ; then echo "Failed to configure domain controller host: ${ADMIN_VM_NAME}"; exit 1; fi
         echo "Domain controller VM extension execution completed"
@@ -82,6 +82,37 @@ else
         if [ $? != 0 ] ; then echo "Failed to configure domain slave host: ${VM_NAME_PREFIX}${i}"; exit 1; fi
         echo "Slave ${VM_NAME_PREFIX}${i} extension execution completed"
     done
+
+    if [ "$ENABLE_DB" == "True" ]; then
+        # Configure data source
+        echo "Configure data source for host: ${ADMIN_VM_NAME}"
+        masterDSScriptUri="${SCRIPT_LOCATION}/jbosseap-setup-master-ds.sh"
+        jdbcDataSourceName=dataSource-$DATABASE_TYPE
+        az vm extension set --verbose --name CustomScript \
+            --resource-group ${RESOURCE_GROUP_NAME} \
+            --vm-name ${ADMIN_VM_NAME} \
+            --publisher Microsoft.Azure.Extensions \
+            --version 2.0 \
+            --settings "{\"fileUris\": [\"${masterDSScriptUri}\", \"${postgresqlDSScriptUri}\", \"${mssqlserverDSScriptUri}\", \"${oracleDSScriptUri}\", \"${mysqlDSScriptUri}\"]}" \
+            --protected-settings "{\"commandToExecute\":\"sh jbosseap-setup-master-ds.sh ${DATABASE_TYPE} ${jdbcDataSourceName} ${JDBC_DATA_SOURCE_JNDI_NAME_BASE64} ${DS_CONNECTION_URL_BASE64} ${DB_USER_BASE64} ${DB_PASSWORD_BASE64}\"}"
+            if [ $? != 0 ] ; then echo  "Failed to configure data source for host: ${ADMIN_VM_NAME}"; exit 1;  fi
+            echo "Data source configuration VM extension execution completed"
+
+        # Test data source connection in worker nodes
+        for ((i = 1; i < NUMBER_OF_INSTANCE; i++)); do
+            echo "Test data source connection in workder node: ${VM_NAME_PREFIX}${i}"
+            slaveTestDSConnScriptUri="${SCRIPT_LOCATION}/jbosseap-test-slave-ds.sh"
+            az vm extension set --verbose --name CustomScript \
+            --resource-group ${RESOURCE_GROUP_NAME} \
+            --vm-name ${VM_NAME_PREFIX}${i} \
+            --publisher Microsoft.Azure.Extensions \
+            --version 2.0 \
+            --settings "{\"fileUris\": [\"${slaveTestDSConnScriptUri}\"]}" \
+            --protected-settings "{\"commandToExecute\":\"sh jbosseap-test-slave-ds.sh ${JBOSS_EAP_USER} ${JBOSS_EAP_PASSWORD_BASE64} ${DOMAIN_CONTROLLER_PRIVATE_IP} ${NUMBER_OF_SERVER_INSTANCE} ${jdbcDataSourceName}\"}"
+            if [ $? != 0 ] ; then echo  "Test data source connection failed for worker node: ${VM_NAME_PREFIX}${i}"; exit 1;  fi
+            echo "Worker node ${VM_NAME_PREFIX}${i} data source connection test extension execution completed"
+        done
+    fi    
 fi
 
 # Delete uami generated before

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-setup-slave.sh
@@ -286,36 +286,6 @@ if [ "$enableDB" == "True" ]; then
     jdbcDataSourceName=dataSource-$dbType
     ./create-ds-${dbType}.sh $EAP_HOME/wildfly "$jdbcDataSourceName" "$jdbcDSJNDIName" "$dsConnectionString" "$databaseUser" "$databasePassword" true true
     echo "Complete to install JDBC driver module" | log
-
-    # Reload servers
-    echo "Reload servers" | log
-    for ((i = 0; i < NUMBER_OF_SERVER_INSTANCE; i++)); do
-        sudo -u jboss $EAP_HOME/wildfly/bin/jboss-cli.sh --connect --controller=${DOMAIN_CONTROLLER_PRIVATE_IP} --user=${JBOSS_EAP_USER} --password=${JBOSS_EAP_PASSWORD} \
-            "/host=${HOST_VM_NAME_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/:reload"
-
-        sudo -u jboss $EAP_HOME/wildfly/bin/jboss-cli.sh --connect --controller=${DOMAIN_CONTROLLER_PRIVATE_IP} --user=${JBOSS_EAP_USER} --password=${JBOSS_EAP_PASSWORD} \
-            "/host=${HOST_VM_NAME_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/:read-attribute(name=server-state)"
-        while [ $? -ne 0 ]
-        do
-            echo "${HOST_VM_NAME_LOWERCASES}-server${i} is starting..." | log
-            sleep 5
-            sudo -u jboss $EAP_HOME/wildfly/bin/jboss-cli.sh --connect --controller=${DOMAIN_CONTROLLER_PRIVATE_IP} --user=${JBOSS_EAP_USER} --password=${JBOSS_EAP_PASSWORD} \
-                "/host=${HOST_VM_NAME_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/:read-attribute(name=server-state)"
-        done
-    done
-    echo "All servers are running now" | log
-
-    # Test connection for the created data source
-    echo "Start to test data source connection" | log
-    for ((i = 0; i < NUMBER_OF_SERVER_INSTANCE; i++)); do
-        sudo -u jboss $EAP_HOME/wildfly/bin/jboss-cli.sh --connect --controller=${DOMAIN_CONTROLLER_PRIVATE_IP} --user=${JBOSS_EAP_USER} --password=${JBOSS_EAP_PASSWORD} \
-            "/host=${HOST_VM_NAME_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/subsystem=datasources/data-source=$jdbcDataSourceName:test-connection-in-pool" | log; flag=${PIPESTATUS[0]}
-        if [ $flag != 0 ]; then 
-            echo "ERROR! Test data source connection failed." >&2 log
-            exit $flag
-        fi
-    done   
-    echo "Complete to test data source connection" | log
 fi
 
 echo "Red Hat JBoss EAP Cluster Intallation End " | log; flag=${PIPESTATUS[0]}

--- a/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-test-slave-ds.sh
+++ b/eap74-rhel8-payg-multivm/src/main/scripts/jbosseap-test-slave-ds.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+log() {
+    while IFS= read -r line; do
+        printf '%s %s\n' "$(date "+%Y-%m-%d %H:%M:%S")" "$line" >> /var/log/jbosseap.install.log
+    done
+}
+
+JBOSS_EAP_USER=${1}
+JBOSS_EAP_PASSWORD_BASE64=${2}
+JBOSS_EAP_PASSWORD=$(echo $JBOSS_EAP_PASSWORD_BASE64 | base64 -d)
+DOMAIN_CONTROLLER_PRIVATE_IP=${3}
+NUMBER_OF_SERVER_INSTANCE=${4}
+jdbcDataSourceName=${5}
+
+FQDN=$(hostname -A)
+FQDN_LOWERCASES=$(echo "${FQDN,,}")
+HOST_VM_NAME=$(hostname)
+HOST_VM_NAME_LOWERCASES=$(echo "${HOST_VM_NAME,,}")
+
+# Load environment variables where EAP_HOME is defined
+source /etc/profile.d/eap_env.sh
+
+echo "Start to test data source connection" | log
+for ((i = 0; i < NUMBER_OF_SERVER_INSTANCE; i++)); do
+    # First try data source connection test using FQDN of the worker node
+    sudo -u jboss $EAP_HOME/wildfly/bin/jboss-cli.sh --connect --controller=${DOMAIN_CONTROLLER_PRIVATE_IP} --user=${JBOSS_EAP_USER} --password=${JBOSS_EAP_PASSWORD} \
+        "/host=${FQDN_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/subsystem=datasources/data-source=$jdbcDataSourceName:test-connection-in-pool" | log; flag=${PIPESTATUS[0]}
+    if [ $flag != 0 ]; then
+        # Retry data source connection test using short hostname of the worker node
+        sudo -u jboss $EAP_HOME/wildfly/bin/jboss-cli.sh --connect --controller=${DOMAIN_CONTROLLER_PRIVATE_IP} --user=${JBOSS_EAP_USER} --password=${JBOSS_EAP_PASSWORD} \
+            "/host=${HOST_VM_NAME_LOWERCASES}/server=${HOST_VM_NAME_LOWERCASES}-server${i}/subsystem=datasources/data-source=$jdbcDataSourceName:test-connection-in-pool" | log; flag=${PIPESTATUS[0]}
+        if [ $flag != 0 ]; then 
+            echo "ERROR! Test data source connection failed." >&2 log
+            exit $flag
+        fi
+    fi
+done
+echo "Complete to test data source connection" | log

--- a/eap74-rhel8-payg-vmss/pom.xml
+++ b/eap74-rhel8-payg-vmss/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-payg-vmss</artifactId>
-    <version>1.0.13</version>
+    <version>1.0.14</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/eap74-rhel8-payg-vmss/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-vmss/src/main/arm/createUiDefinition.json
@@ -722,8 +722,8 @@
                                 "defaultValue": "",
                                 "constraints": {
                                     "required": true,
-                                    "regex": "^[a-zA-Z0-9./_-]{1,30}$",
-                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters, numbers, hyphens (-), underscores (_), periods (.) and slashes (/)."
+                                    "regex": "^[a-zA-Z0-9:./_-]+$",
+                                    "validationMessage": "The value must only contain letters, numbers, colon (:), hyphens (-), underscores (_), periods (.) and slashes (/)."
                                 },
                                 "visible": true
                             },

--- a/eap74-rhel8-payg/pom.xml
+++ b/eap74-rhel8-payg/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.rhel.jboss.azure</groupId>
     <artifactId>eap74-rhel8-payg</artifactId>
-    <version>1.0.11</version>
+    <version>1.0.12</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/eap74-rhel8-payg/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg/src/main/arm/createUiDefinition.json
@@ -598,8 +598,8 @@
                                 "defaultValue": "",
                                 "constraints": {
                                     "required": true,
-                                    "regex": "^[a-zA-Z0-9./_-]{1,30}$",
-                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters, numbers, hyphens (-), underscores (_), periods (.) and slashes (/)."
+                                    "regex": "^[a-zA-Z0-9:./_-]+$",
+                                    "validationMessage": "The value must only contain letters, numbers, colon (:), hyphens (-), underscores (_), periods (.) and slashes (/)."
                                 },
                                 "visible": true
                             },


### PR DESCRIPTION
The PR is to fix the regression issue that data source creation in a domain mode cluster failed.

During the testing, another issue is observed that the jndi regex doesn't allow colon and has maximum length limitation as 30 (e.g., `java:jboss/datasources/JavaEECafeDB`), which is fixed in [update jndi regex to allow colon and remove maximum length](https://github.com/Azure/rhel-jboss-templates/pull/191/commits/98706fe0b733ac13313735ecb7077b52ad996a78).

## Testing

Pipelines successfully ran:
* DB enabled: [Validate payg-multivm offer](https://github.com/majguo/rhel-jboss-templates/actions/runs/4602259327)
* DB disabled: [Validate payg-multivm offer](https://github.com/majguo/rhel-jboss-templates/actions/runs/4602528290)
* DB enabled: [Validate byos-multivm offer](https://github.com/majguo/rhel-jboss-templates/actions/runs/4602814034)
* DB disabled: [Validate byos-multivm offer](https://github.com/majguo/rhel-jboss-templates/actions/runs/4603893618)

Also tested preview link [Azure portal preview - Plan Id: eap74-rhel8-payg-multivm](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20220323-zheng-test-offer-previeweap74-rhel8-payg-multivm) by deploying a cluster with DB enabled, which works as expected.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>