### PR TITLE
Use drop-and-create

### DIFF
--- a/eap-coffee-app/src/main/resources/META-INF/persistence.xml
+++ b/eap-coffee-app/src/main/resources/META-INF/persistence.xml
@@ -8,7 +8,7 @@
         <properties>
             <property
                 name="javax.persistence.schema-generation.database.action"
-                value="create" />
+                value="drop-and-create" />
             <property name="openjpa.jdbc.SynchronizeMappings"
                 value="buildSchema" />
             <property name="eclipselink.logging.level.sql" value="FINE" />


### PR DESCRIPTION
The PR includes a quick fix for the following issue when the app is deployed and running on an ARO cluster, using `drop-and-create` instead of `create` for property **javax.persistence.schema-generation.database.action** as it complains:
* `Table 'coffee' already exists`
* `Table 'hibernate_sequence' already exists`

```
18:56:10,853 WARN  [org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl] (ServerService Thread Pool -- 80) GenerationTarget encountered exception accepting command : Error executing DDL "create table Coffee (id bigint not null, name varchar(255), price double precision, primary key (id)) engine=InnoDB" via JDBC Statement: org.hibernate.tool.schema.spi.CommandAcceptanceException: Error executing DDL "create table Coffee (id bigint not null, name varchar(255), price double precision, primary key (id)) engine=InnoDB" via JDBC Statement
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase.accept(GenerationTargetToDatabase.java:67)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.SchemaCreatorImpl.applySqlString(SchemaCreatorImpl.java:440)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.SchemaCreatorImpl.applySqlStrings(SchemaCreatorImpl.java:424)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.SchemaCreatorImpl.createFromMetadata(SchemaCreatorImpl.java:315)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.SchemaCreatorImpl.performCreation(SchemaCreatorImpl.java:166)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.SchemaCreatorImpl.doCreation(SchemaCreatorImpl.java:135)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.SchemaCreatorImpl.doCreation(SchemaCreatorImpl.java:121)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.performDatabaseAction(SchemaManagementToolCoordinator.java:129)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.process(SchemaManagementToolCoordinator.java:72)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.internal.SessionFactoryImpl.<init>(SessionFactoryImpl.java:310)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.boot.internal.SessionFactoryBuilderImpl.build(SessionFactoryBuilderImpl.java:467)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.build(EntityManagerFactoryBuilderImpl.java:1250)
        at org.hibernate.jipijapa-hibernate5-3@7.4.10.GA-redhat-00002//org.jboss.as.jpa.hibernate5.TwoPhaseBootstrapImpl.build(TwoPhaseBootstrapImpl.java:44)
        at org.jboss.as.jpa@7.4.10.GA-redhat-00002//org.jboss.as.jpa.service.PersistenceUnitServiceImpl$1$1.run(PersistenceUnitServiceImpl.java:170)
        at org.jboss.as.jpa@7.4.10.GA-redhat-00002//org.jboss.as.jpa.service.PersistenceUnitServiceImpl$1$1.run(PersistenceUnitServiceImpl.java:128)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at org.wildfly.security.elytron-private@1.15.16.Final-redhat-00001//org.wildfly.security.manager.WildFlySecurityManager.doChecked(WildFlySecurityManager.java:664)
        at org.jboss.as.jpa@7.4.10.GA-redhat-00002//org.jboss.as.jpa.service.PersistenceUnitServiceImpl$1.run(PersistenceUnitServiceImpl.java:213)
        at org.jboss.threads@2.4.0.Final-redhat-00001//org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)
        at org.jboss.threads@2.4.0.Final-redhat-00001//org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:1990)
        at org.jboss.threads@2.4.0.Final-redhat-00001//org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1486)
        at org.jboss.threads@2.4.0.Final-redhat-00001//org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1377)
        at java.base/java.lang.Thread.run(Thread.java:829)
        at org.jboss.threads@2.4.0.Final-redhat-00001//org.jboss.threads.JBossThread.run(JBossThread.java:513)
Caused by: java.sql.SQLSyntaxErrorException: Table 'coffee' already exists
        at com.mysql@8.0.32//com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:120)
        at com.mysql@8.0.32//com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
        at com.mysql@8.0.32//com.mysql.cj.jdbc.StatementImpl.executeInternal(StatementImpl.java:763)
        at com.mysql@8.0.32//com.mysql.cj.jdbc.StatementImpl.execute(StatementImpl.java:648)
        at com.mysql@8.0.32//com.mysql.cj.jdbc.StatementWrapper.execute(StatementWrapper.java:529)
        at org.jboss.ironjacamar.jdbcadapters@1.5.11.Final-redhat-00001//org.jboss.jca.adapters.jdbc.WrappedStatement.execute(WrappedStatement.java:198)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase.accept(GenerationTargetToDatabase.java:54)
        ... 23 more

18:56:10,854 INFO  [stdout] (ServerService Thread Pool -- 80) Hibernate: create table hibernate_sequence (next_val bigint) engine=InnoDB
18:56:10,869 WARN  [org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl] (ServerService Thread Pool -- 80) GenerationTarget encountered exception accepting command : Error executing DDL "create table hibernate_sequence (next_val bigint) engine=InnoDB" via JDBC Statement: org.hibernate.tool.schema.spi.CommandAcceptanceException: Error executing DDL "create table hibernate_sequence (next_val bigint) engine=InnoDB" via JDBC Statement
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase.accept(GenerationTargetToDatabase.java:67)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.SchemaCreatorImpl.applySqlString(SchemaCreatorImpl.java:440)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.SchemaCreatorImpl.applySqlStrings(SchemaCreatorImpl.java:424)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.SchemaCreatorImpl.createFromMetadata(SchemaCreatorImpl.java:315)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.SchemaCreatorImpl.performCreation(SchemaCreatorImpl.java:166)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.SchemaCreatorImpl.doCreation(SchemaCreatorImpl.java:135)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.SchemaCreatorImpl.doCreation(SchemaCreatorImpl.java:121)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.performDatabaseAction(SchemaManagementToolCoordinator.java:129)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.process(SchemaManagementToolCoordinator.java:72)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.internal.SessionFactoryImpl.<init>(SessionFactoryImpl.java:310)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.boot.internal.SessionFactoryBuilderImpl.build(SessionFactoryBuilderImpl.java:467)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.build(EntityManagerFactoryBuilderImpl.java:1250)
        at org.hibernate.jipijapa-hibernate5-3@7.4.10.GA-redhat-00002//org.jboss.as.jpa.hibernate5.TwoPhaseBootstrapImpl.build(TwoPhaseBootstrapImpl.java:44)
        at org.jboss.as.jpa@7.4.10.GA-redhat-00002//org.jboss.as.jpa.service.PersistenceUnitServiceImpl$1$1.run(PersistenceUnitServiceImpl.java:170)
        at org.jboss.as.jpa@7.4.10.GA-redhat-00002//org.jboss.as.jpa.service.PersistenceUnitServiceImpl$1$1.run(PersistenceUnitServiceImpl.java:128)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at org.wildfly.security.elytron-private@1.15.16.Final-redhat-00001//org.wildfly.security.manager.WildFlySecurityManager.doChecked(WildFlySecurityManager.java:664)
        at org.jboss.as.jpa@7.4.10.GA-redhat-00002//org.jboss.as.jpa.service.PersistenceUnitServiceImpl$1.run(PersistenceUnitServiceImpl.java:213)
        at org.jboss.threads@2.4.0.Final-redhat-00001//org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)
        at org.jboss.threads@2.4.0.Final-redhat-00001//org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:1990)
        at org.jboss.threads@2.4.0.Final-redhat-00001//org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1486)
        at org.jboss.threads@2.4.0.Final-redhat-00001//org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1377)
        at java.base/java.lang.Thread.run(Thread.java:829)
        at org.jboss.threads@2.4.0.Final-redhat-00001//org.jboss.threads.JBossThread.run(JBossThread.java:513)
Caused by: java.sql.SQLSyntaxErrorException: Table 'hibernate_sequence' already exists
        at com.mysql@8.0.32//com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:120)
        at com.mysql@8.0.32//com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
        at com.mysql@8.0.32//com.mysql.cj.jdbc.StatementImpl.executeInternal(StatementImpl.java:763)
        at com.mysql@8.0.32//com.mysql.cj.jdbc.StatementImpl.execute(StatementImpl.java:648)
        at com.mysql@8.0.32//com.mysql.cj.jdbc.StatementWrapper.execute(StatementWrapper.java:529)
        at org.jboss.ironjacamar.jdbcadapters@1.5.11.Final-redhat-00001//org.jboss.jca.adapters.jdbc.WrappedStatement.execute(WrappedStatement.java:198)
        at org.hibernate@5.3.28.Final-redhat-00001//org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase.accept(GenerationTargetToDatabase.java:54)
        ... 23 more
```

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>