### PR TITLE
Run same `arm-ttk` tests executed in partner center pipeline for jboss-eap-on-vm repos

### DIFF
--- a/.github/workflows/build-artifact-byos-multivm.yaml
+++ b/.github/workflows/build-artifact-byos-multivm.yaml
@@ -60,12 +60,10 @@ jobs:
                 repository: Azure/azure-javaee-iaas
                 path: azure-javaee-iaas
                 ref: ${{ env.refJavaee }}
-            - name: Checkout arm-ttk
-              uses: actions/checkout@v3
-              with:
-                repository: Azure/arm-ttk
-                path: arm-ttk
-                ref: ${{ env.refArmttk }}
+            - name: Download arm-ttk used in partner center pipeline
+              run: |
+                wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
+                unzip arm-template-toolkit.zip -d arm-ttk
             - name: Build azure-javaee-iaas
               run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
             - name: Checkout ${{ env.repoName }}

--- a/.github/workflows/build-artifact-byos-single.yaml
+++ b/.github/workflows/build-artifact-byos-single.yaml
@@ -61,12 +61,10 @@ jobs:
                 repository: Azure/azure-javaee-iaas
                 path: azure-javaee-iaas
                 ref: ${{ env.refJavaee }}
-            - name: Checkout arm-ttk
-              uses: actions/checkout@v3
-              with:
-                repository: Azure/arm-ttk
-                path: arm-ttk
-                ref: ${{ env.refArmttk }}
+            - name: Download arm-ttk used in partner center pipeline
+              run: |
+                wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
+                unzip arm-template-toolkit.zip -d arm-ttk
             - name: Build azure-javaee-iaas
               run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
             - name: Checkout ${{ env.repoName }}

--- a/.github/workflows/build-artifact-byos-vmss.yaml
+++ b/.github/workflows/build-artifact-byos-vmss.yaml
@@ -61,12 +61,10 @@ jobs:
                 repository: Azure/azure-javaee-iaas
                 path: azure-javaee-iaas
                 ref: ${{ env.refJavaee }}
-            - name: Checkout arm-ttk
-              uses: actions/checkout@v3
-              with:
-                repository: Azure/arm-ttk
-                path: arm-ttk
-                ref: ${{ env.refArmttk }}
+            - name: Download arm-ttk used in partner center pipeline
+              run: |
+                wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
+                unzip arm-template-toolkit.zip -d arm-ttk
             - name: Build azure-javaee-iaas
               run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
             - name: Checkout ${{ env.repoName }}

--- a/.github/workflows/build-artifact-payg-multivm.yaml
+++ b/.github/workflows/build-artifact-payg-multivm.yaml
@@ -60,12 +60,11 @@ jobs:
                 repository: Azure/azure-javaee-iaas
                 path: azure-javaee-iaas
                 ref: ${{ env.refJavaee }}
-            - name: Checkout arm-ttk
-              uses: actions/checkout@v3
-              with:
-                repository: Azure/arm-ttk
-                path: arm-ttk
-                ref: ${{ env.refArmttk }}
+            - name: Download arm-ttk used in partner center pipeline
+              run: |
+                wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
+                unzip arm-template-toolkit.zip -d arm-ttk
+
             - name: Build azure-javaee-iaas
               run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
             - name: Checkout ${{ env.repoName }}

--- a/.github/workflows/build-artifact-payg-single.yaml
+++ b/.github/workflows/build-artifact-payg-single.yaml
@@ -61,12 +61,10 @@ jobs:
                 repository: Azure/azure-javaee-iaas
                 path: azure-javaee-iaas
                 ref: ${{ env.refJavaee }}
-            - name: Checkout arm-ttk
-              uses: actions/checkout@v3
-              with:
-                repository: Azure/arm-ttk
-                path: arm-ttk
-                ref: ${{ env.refArmttk }}
+            - name: Download arm-ttk used in partner center pipeline
+              run: |
+                wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
+                unzip arm-template-toolkit.zip -d arm-ttk
             - name: Build azure-javaee-iaas
               run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
             - name: Checkout ${{ env.repoName }}

--- a/.github/workflows/build-artifact-payg-vmss.yaml
+++ b/.github/workflows/build-artifact-payg-vmss.yaml
@@ -61,12 +61,10 @@ jobs:
                 repository: Azure/azure-javaee-iaas
                 path: azure-javaee-iaas
                 ref: ${{ env.refJavaee }}
-            - name: Checkout arm-ttk
-              uses: actions/checkout@v3
-              with:
-                repository: Azure/arm-ttk
-                path: arm-ttk
-                ref: ${{ env.refArmttk }}
+            - name: Download arm-ttk used in partner center pipeline
+              run: |
+                wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
+                unzip arm-template-toolkit.zip -d arm-ttk
             - name: Build azure-javaee-iaas
               run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
             - name: Checkout ${{ env.repoName }}

--- a/README.md
+++ b/README.md
@@ -4,25 +4,15 @@ This repo contains JBoss EAP Marketplace templates for use on Azure Marketplace.
 
 ## Deployment Description
 
-### Red Hat JBoss EAP on VMs
-
 There are three different types of EAP on VM offers based on their outcomes.
 
-#### JBoss EAP standalone on RHEL VM(PAYG/BYOS)
+| Type   | Offer                                         | Description                                                                                                                                                                                                 |
+|--------|-----------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| on VMs | JBoss EAP standalone on RHEL VM(PAYG/BYOS)    | [Deployment description](https://htmlpreview.github.io/?https://github.com/azure-javaee/rhel-jboss-templates/blob/main/eap74-rhel8-payg/src/main/resources/marketing-artifacts/partner-center.html)         |
+| on VMs | JBoss EAP Cluster on VM Scale Sets(PAYG/BYOS) | [Deployment description](https://htmlpreview.github.io/?https://github.com/azure-javaee/rhel-jboss-templates/blob/main/eap74-rhel8-payg-vmss/src/main/resources/marketing-artifacts/partner-center.html)    |
+| on VMs | JBoss EAP Cluster on VMs(PAYG/BYOS)           | [Deployment description](https://htmlpreview.github.io/?https://github.com/azure-javaee/rhel-jboss-templates/blob/main/eap74-rhel8-payg-multivm/src/main/resources/marketing-artifacts/partner-center.html) |
+| on ARO | JBoss EAP on ARO                              | [Deployment description](https://htmlpreview.github.io/?https://github.com/azure-javaee/rhel-jboss-templates/blob/main/eap-aro/src/main/resources/marketing-artifacts/partner-center.html)                  |
 
-[Deployment description](eap74-rhel8-payg/src/main/resources/marketing-artifacts/partner-center.html)
-
-#### JBoss EAP Cluster on VM Scale Sets(PAYG/BYOS)
-
-[Deployment description](eap74-rhel8-payg-vmss/src/main/resources/marketing-artifacts/partner-center.html)
-
-#### JBoss EAP Cluster on VMs(PAYG/BYOS)
-
-[Deployment description](eap74-rhel8-payg-multivm/src/main/resources/marketing-artifacts/partner-center.html)
-
-### Red Hat JBoss EAP on ARO
-
-[Deployment description](eap-aro/src/main/resources/marketing-artifacts/partner-center.html)
 
 ## Build zipped offers
 1. Clean up the folder offers. This step is optional.


### PR DESCRIPTION
## Scope
The user story is to apply the idea above to [Azure/rhel-jboss-templates](https://github.com/Azure/rhel-jboss-templates) except the sub-folder [rhel-jboss-templates/eap-aro](https://github.com/Azure/rhel-jboss-templates/tree/main/eap-aro)

## Goal
1. use partner's arm-ttk
2. update README.md

## Tests
✅ Github actions passed;