### PR TITLE
Remove Setup tmate session step from the build action.

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -85,10 +85,6 @@ runs:
       run: |
         mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests --file ${{ inputs.offerName }}/pom.xml
 
-    - name: Setup tmate session
-      if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3
-
     - name: Generate artifact file name and path
       id: artifact_file
       shell: bash


### PR DESCRIPTION
## Context
Remove Setup tmate session step from the build action, this is only used for debugging.