### PR TITLE
Fix issues detected when running integration tests

### DIFF
--- a/eap-aro/src/main/scripts/jboss-setup.sh
+++ b/eap-aro/src/main/scripts/jboss-setup.sh
@@ -382,7 +382,7 @@ consoleUrl=$(az aro show -g $RESOURCE_GROUP -n $CLUSTER_NAME --query 'consolePro
 
 # Install the OpenShift CLI
 downloadUrl=$(echo $consoleUrl | sed -e "s/https:\/\/console/https:\/\/downloads/g")
-wget ${downloadUrl}amd64/linux/oc.tar -q -P ~
+wget --no-check-certificate ${downloadUrl}amd64/linux/oc.tar -q -P ~
 mkdir ~/openshift
 tar xvf ~/oc.tar -C ~/openshift
 echo 'export PATH=$PATH:~/openshift' >> ~/.bash_profile && source ~/.bash_profile


### PR DESCRIPTION
## Context
Refer the solution in this [PR](https://github.com/WASdev/azure.liberty.aro/pull/109).

Fix wget command to include `--no-check-certificate` flag when downloading oc.tar file from the specified URL.