### PR TITLE
Bugfix: Storage account name in Jboss eap workflows is not valid

### DIFF
--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -22,9 +22,9 @@ on:
 env:
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
     location: eastus
-    domainResourceGroup: multivm-domain-${{ github.run_id }}-${{ github.run_number }}
-    standaloneResourceGroup: multivm-standalone-${{ github.run_id }}-${{ github.run_number }}
-    dependencyResourceGroup: multivm-dep-${{ github.run_id }}-${{ github.run_number }}
+    domainResourceGroup: multivm-domain-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}
+    standaloneResourceGroup: multivm-standalone-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}
+    dependencyResourceGroup: multivm-dep-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}
     vmName: ${{ github.run_id }}${{ github.run_number }}vm
     asName: ${{ github.run_id }}${{ github.run_number }}as
     adminUsername: azureadmin
@@ -33,7 +33,7 @@ env:
     domainOperatingMode: managed-domain
     standaloneOperatingMode: standalone
     domainBootStorageAccountName: ${{ github.run_id }}${{ github.run_number }}domainsa
-    standaloneBootStorageAccountName: ${{ github.run_id }}${{ github.run_number }}standalonesa
+    standaloneBootStorageAccountName: ${{ github.run_id }}${{ github.run_number }}standsa
     dbInstanceName: db${{ github.run_id }}${{ github.run_number }}
     dbPassword: ${{ secrets.DATABASE_PASSWORD }}
     jbossEAPUserName: jbossadmin

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -23,7 +23,7 @@ env:
     azCliVersion: 2.30.0
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
     location: eastus
-    singleResourceGroup: single-${{ github.run_id }}-${{ github.run_number }}
+    singleResourceGroup: single-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}
     vmName: ${{ github.run_id }}${{ github.run_number }}vm
     adminUsername: azureadmin
     password: ${{ secrets.VM_PASSWORD }}

--- a/.github/workflows/validate-byos-vmss.yaml
+++ b/.github/workflows/validate-byos-vmss.yaml
@@ -23,7 +23,7 @@ env:
     azCliVersion: 2.30.0
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
     location: eastus
-    vmssResourceGroup: vmss-${{ github.run_id }}-${{ github.run_number }}
+    vmssResourceGroup: vmss-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}
     vmName: ${{ github.run_id }}${{ github.run_number }}vm
     vmssName: jbossvmss
     asName: ${{ github.run_id }}${{ github.run_number }}as

--- a/.github/workflows/validate-eap-aro.yaml
+++ b/.github/workflows/validate-eap-aro.yaml
@@ -7,7 +7,7 @@ on:
 env:
   azCliVersion: 2.30.0
   location: eastus
-  aroResourceGroup: aro-${{ github.run_id }}-${{ github.run_number }}
+  aroResourceGroup: aro-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}
   aroTestBranchName: aro-cicd-${{ github.run_id }}-${{ github.run_number }}
 
   azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/validate-payg-multivm.yaml
+++ b/.github/workflows/validate-payg-multivm.yaml
@@ -22,9 +22,9 @@ on:
 env:
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
     location: eastus
-    domainResourceGroup: multivm-domain-${{ github.run_id }}-${{ github.run_number }}
-    standaloneResourceGroup: multivm-standalone-${{ github.run_id }}-${{ github.run_number }}
-    dependencyResourceGroup: multivm-dep-${{ github.run_id }}-${{ github.run_number }}
+    domainResourceGroup: multivm-domain-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}
+    standaloneResourceGroup: multivm-standalone-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}
+    dependencyResourceGroup: multivm-dep-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}
     vmName: ${{ github.run_id }}${{ github.run_number }}vm
     asName: ${{ github.run_id }}${{ github.run_number }}as
     adminUsername: azureadmin
@@ -33,7 +33,7 @@ env:
     domainOperatingMode: managed-domain
     standaloneOperatingMode: standalone
     domainBootStorageAccountName: ${{ github.run_id }}${{ github.run_number }}domainsa
-    standaloneBootStorageAccountName: ${{ github.run_id }}${{ github.run_number }}standalonesa
+    standaloneBootStorageAccountName: ${{ github.run_id }}${{ github.run_number }}standsa
     dbInstanceName: db${{ github.run_id }}${{ github.run_number }}
     dbPassword: ${{ secrets.DATABASE_PASSWORD }}
     jbossEAPUserName: jbossadmin

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -23,7 +23,7 @@ env:
     azCliVersion: 2.30.0
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
     location: eastus
-    singleResourceGroup: single-${{ github.run_id }}-${{ github.run_number }}
+    singleResourceGroup: single-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}
     vmName: ${{ github.run_id }}${{ github.run_number }}vm
     adminUsername: azureadmin
     password: ${{ secrets.VM_PASSWORD }}

--- a/.github/workflows/validate-payg-vmss.yaml
+++ b/.github/workflows/validate-payg-vmss.yaml
@@ -23,7 +23,7 @@ env:
     azCliVersion: 2.30.0
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
     location: eastus
-    vmssResourceGroup: vmss-${{ github.run_id }}-${{ github.run_number }}
+    vmssResourceGroup: vmss-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}
     vmName: ${{ github.run_id }}${{ github.run_number }}vm
     vmssName: jbossvmss
     asName: ${{ github.run_id }}${{ github.run_number }}as


### PR DESCRIPTION
## Context
Refer to this [log](https://github.com/azure-javaee/rhel-jboss-templates/actions/runs/8478301265/job/23230514837), the standaloneBootStorageAccountName in [validate-payg-multivm.yaml](https://github.com/azure-javaee/rhel-jboss-templates/blob/954330fc7619f6c21bfa2440e53c278f1167d0c8/.github/workflows/validate-payg-multivm.yaml#L36) and [validate-byos-multivm.yaml](https://github.com/azure-javaee/rhel-jboss-templates/blob/954330fc7619f6c21bfa2440e53c278f1167d0c8/.github/workflows/validate-byos-multivm.yaml#L36C5-L36C37) are not valid.
![image](https://github.com/Azure/rhel-jboss-templates/assets/4465723/a2c29713-d8db-4598-881a-8c3bdda41ba1)


## PR Changes
1. Bugfix: Storage account name in Jboss eap workflows is not valid
2. Code Refactor: update resource group names to include repository owner in Azure workflows.

## Tests
### Test for bug
- [Workflow job log](https://github.com/azure-javaee/rhel-jboss-templates/actions/runs/8478982884)
- ✅ <img width="353" alt="image" src="https://github.com/Azure/rhel-jboss-templates/assets/4465723/f853d96a-dbcd-4af0-ac36-b1fa8d57d5a1">

### Test for Code Refactor ✅
The resource group contains the `repository owner` .
![image](https://github.com/Azure/rhel-jboss-templates/assets/4465723/f6214ca4-f9ea-4af9-86b4-8f4224997093)

