### PR TITLE
Enable publicIp and a networkSecurityGroup rule for single vm offers

### DIFF
--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -14,10 +14,11 @@ on:
         - mysql
         - postgresql
         - none
-      isForDemo:
-        description: 'If set to true, resources will not be deleted'
+      deleteAzureResources:
+        description: 'Delete Azure resources at the end'
         required: true
-        default: 'false'
+        type: boolean
+        default: true
 
 env:
     azCliVersion: 2.30.0
@@ -48,7 +49,6 @@ env:
 jobs:
     preflight:
         outputs:
-          isForDemo: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.isForDemo }}
           artifactName: ${{steps.build.outputs.artifactName}}
         runs-on: ubuntu-latest
         steps:
@@ -61,12 +61,6 @@ jobs:
                 offerName: ${{ env.offerName }}
                 token: ${{ secrets.GITHUB_TOKEN }}
                 workflowType: "validate"
-            - name: Setup environment variables
-              id: setup-env-variables-based-on-dispatch-event
-              run: |
-                isForDemo=${{ github.event.inputs.isForDemo }}
-                echo "##[set-output name=isForDemo;]${isForDemo}"
-                echo "isForDemo=${isForDemo}" >> "$GITHUB_ENV"
     deploy-single:
         needs: preflight
         runs-on: ubuntu-latest
@@ -295,7 +289,7 @@ jobs:
                 fi
                 exit 0
             - name: Unregister VM
-              if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
+              if: ${{ (github.event_name == 'workflow_dispatch' && inputs.deleteAzureResources) }}
               uses: azure/CLI@v1
               with:
                 azcliversion: ${{ env.azCliVersion }}
@@ -318,7 +312,7 @@ jobs:
           with:
             path: rhel-jboss-templates
         - name: Delete Resource Group
-          if: always()
+          if: ${{ (github.event_name == 'workflow_dispatch' && inputs.deleteAzureResources) }}
           id: delete-resource-group
           run: |
             echo "delete... " $singleResourceGroup

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -276,7 +276,7 @@ jobs:
               with:
                 azcliversion: ${{ env.azCliVersion }}
                 inlineScript: |
-                    publicip=$(az network public-ip show --name 'vmip' --resource-group $singleResourceGroup --query ipAddress -o tsv)
+                    publicip=$(az network public-ip show --name 'jbosseapVm-ip' --resource-group $singleResourceGroup --query ipAddress -o tsv)
                     echo "##[set-output name=publicip;]${publicip}"
             - name: Verify console is accessible
               run: |

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -270,36 +270,17 @@ jobs:
                     --name single \
                     --parameters @rhel-jboss-templates/eap74-rhel8-byos/src/test/parameters-test-single.json \
                     --template-file rhel-jboss-templates/eap74-rhel8-byos/mainTemplate.json
-            - name: Setup public IP
-              id: setup_public_lb
+            - name: Get public IP
+              id: get_public_ip
               uses: azure/CLI@v1
               with:
                 azcliversion: ${{ env.azCliVersion }}
                 inlineScript: |
-                    # Create NSG rule to allow inbound traffic to port 9990
-                    az network nsg rule create -g ${{ env.singleResourceGroup }} --nsg-name ${{ env.nsgName }} -n rule_9990 --priority 100 \
-                      --source-address-prefixes '*' --source-port-ranges '*' \
-                      --destination-address-prefixes '*' --destination-port-ranges 9990 8080 --access Allow \
-                      --protocol '*' --description "allow 9990,8080"
-                    # Create public IP
-                    az network public-ip create --name ${{ env.testPubIpName }} --resource-group ${{ env.singleResourceGroup }}
-                    # Query VM NIC name
-                    nicId=$(az vm nic list --vm-name $vmName --resource-group $singleResourceGroup --query [0].id -o tsv)
-                    nicName=$(az vm nic show --vm-name $vmName --resource-group $singleResourceGroup --nic $nicId --query name -o tsv)
-                    # Query VM NIC ipconfig name
-                    configName=$(az network nic ip-config list --nic-name $nicName --resource-group $singleResourceGroup --query [0].name -o tsv)
-                    # Update configuration, associate the public IP to the VM
-                    az network nic ip-config update \
-                      --name $configName \
-                      --nic-name $nicName \
-                      --resource-group ${{ env.singleResourceGroup }} \
-                      --public-ip-address ${{ env.testPubIpName }}
-                    # Query public IP for later use
-                    publicip=$(az network public-ip show --name ${{ env.testPubIpName }} --resource-group $singleResourceGroup --query ipAddress -o tsv)
+                    publicip=$(az network public-ip show --name 'vmip' --resource-group $singleResourceGroup --query ipAddress -o tsv)
                     echo "##[set-output name=publicip;]${publicip}"
             - name: Verify console is accessible
               run: |
-                publicip=${{steps.setup_public_lb.outputs.publicip}}
+                publicip=${{steps.get_public_ip.outputs.publicip}}
                 echo "publicip: " $publicip
                 CURL_RETRY_PARMS="--connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused"
                 echo "Verifying console is accessible"

--- a/.github/workflows/validate-byos-vmss.yaml
+++ b/.github/workflows/validate-byos-vmss.yaml
@@ -14,10 +14,11 @@ on:
         - mysql
         - postgresql
         - none
-      isForDemo:
-        description: 'If set to true, resources will not be deleted'
+      deleteAzureResources:
+        description: 'Delete Azure resources at the end'
         required: true
-        default: 'false'
+        type: boolean
+        default: true
 
 env:
     azCliVersion: 2.30.0
@@ -52,7 +53,6 @@ env:
 jobs:
     preflight:
         outputs:
-          isForDemo: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.isForDemo }}
           artifactName: ${{steps.build.outputs.artifactName}}
         runs-on: ubuntu-latest
         steps:
@@ -65,12 +65,6 @@ jobs:
                 offerName: ${{ env.offerName }}
                 token: ${{ secrets.GITHUB_TOKEN }}
                 workflowType: "validate"
-            - name: Setup environment variables
-              id: setup-env-variables-based-on-dispatch-event
-              run: |
-                isForDemo=${{ github.event.inputs.isForDemo }}
-                echo "##[set-output name=isForDemo;]${isForDemo}"
-                echo "isForDemo=${isForDemo}" >> "$GITHUB_ENV"
     deploy-vmss:
         needs: preflight
         runs-on: ubuntu-latest
@@ -304,7 +298,7 @@ jobs:
                 fi
                 exit 0
             - name: Unregister before deleting resources
-              if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
+              if: ${{ (github.event_name == 'workflow_dispatch' && inputs.deleteAzureResources) }}
               uses: azure/CLI@v1
               with:
                 azcliversion: ${{ env.azCliVersion }}
@@ -330,7 +324,7 @@ jobs:
           with:
             path: rhel-jboss-templates
         - name: Delete Resource Group
-          if: always()
+          if: ${{ (github.event_name == 'workflow_dispatch' && inputs.deleteAzureResources) }}
           id: delete-resource-group
           run: |
             echo "delete... " $vmssResourceGroup

--- a/.github/workflows/validate-payg-multivm.yaml
+++ b/.github/workflows/validate-payg-multivm.yaml
@@ -14,10 +14,11 @@ on:
         - mysql
         - postgresql
         - none
-      isForDemo:
-        description: 'If set to true, resources will not be deleted'
+      deleteAzureResources:
+        description: 'Delete Azure resources at the end'
         required: true
-        default: 'false'
+        type: boolean
+        default: true
 
 env:
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
@@ -52,7 +53,6 @@ env:
 jobs:
     preflight:
         outputs:
-          isForDemo: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.isForDemo }}
           artifactName: ${{steps.build.outputs.artifactName}}
         runs-on: ubuntu-latest
         steps:
@@ -65,11 +65,6 @@ jobs:
                 offerName: ${{ env.offerName }}
                 token: ${{ secrets.GITHUB_TOKEN }}
                 workflowType: "validate"
-            - name: Setup environment variables
-              id: setup-env-variables-based-on-dispatch-event
-              run: |
-                isForDemo=${{ github.event.inputs.isForDemo }}
-                echo "isForDemo=${isForDemo}" >> "$GITHUB_OUTPUT"
 
     deploy-dependent-resources:
         needs: preflight
@@ -395,7 +390,7 @@ jobs:
                 fi
                 exit 0
             - name: Unregister before deleting resources
-              if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
+              if: ${{ (github.event_name == 'workflow_dispatch' && inputs.deleteAzureResources) }}
               uses: azure/CLI@v1
               with:
                 azcliversion: ${{ env.azCliVersion }}
@@ -564,7 +559,7 @@ jobs:
                 fi
                 exit 0
             - name: Unregister before deleting resources
-              if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
+              if: ${{ (github.event_name == 'workflow_dispatch' && inputs.deleteAzureResources) }}
               uses: azure/CLI@v1
               with:
                 azcliversion: ${{ env.azCliVersion }}
@@ -592,17 +587,17 @@ jobs:
           with:
             path: rhel-jboss-templates
         - name: Delete Dependent Resource Group
-          if: always()
+          if: ${{ (github.event_name == 'workflow_dispatch' && inputs.deleteAzureResources) }}
           run: |
             az group delete --yes --no-wait --name ${{ env.dependencyResourceGroup }}
         - name: Delete Standalone Resource Group
-          if: always()
+          if: ${{ (github.event_name == 'workflow_dispatch' && inputs.deleteAzureResources) }}
           id: delete-standalone-resource-group
           run: |
             echo "delete... " $standaloneResourceGroup
             az group delete --yes --no-wait --verbose --name $standaloneResourceGroup
         - name: Delete Domain Resource Group
-          if: always()
+          if: ${{ (github.event_name == 'workflow_dispatch' && inputs.deleteAzureResources) }}
           id: delete-domain-resource-group
           run: |
             echo "delete... " $domainResourceGroup

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -14,10 +14,11 @@ on:
         - mysql
         - postgresql
         - none
-      isForDemo:
-        description: 'If set to true, resources will not be deleted'
+      deleteAzureResources:
+        description: 'Delete Azure resources at the end'
         required: true
-        default: 'false'
+        type: boolean
+        default: true
 
 env:
     azCliVersion: 2.30.0
@@ -47,7 +48,6 @@ env:
 jobs:
     preflight:
         outputs:
-          isForDemo: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.isForDemo }}
           artifactName: ${{steps.build.outputs.artifactName}}
         runs-on: ubuntu-latest
         steps:
@@ -60,12 +60,6 @@ jobs:
                 offerName: ${{ env.offerName }}
                 token: ${{ secrets.GITHUB_TOKEN }}
                 workflowType: "validate"
-            - name: Setup environment variables
-              id: setup-env-variables-based-on-dispatch-event
-              run: |
-                isForDemo=${{ github.event.inputs.isForDemo }}
-                echo "##[set-output name=isForDemo;]${isForDemo}"
-                echo "isForDemo=${isForDemo}" >> "$GITHUB_ENV"
     deploy-single:
         needs: preflight
         runs-on: ubuntu-latest
@@ -295,7 +289,7 @@ jobs:
                 fi
                 exit 0
             - name: Unregister VM
-              if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
+              if: ${{ (github.event_name == 'workflow_dispatch' && inputs.deleteAzureResources) }}
               uses: azure/CLI@v1
               with:
                 azcliversion: ${{ env.azCliVersion }}
@@ -318,7 +312,7 @@ jobs:
           with:
             path: rhel-jboss-templates
         - name: Delete Resource Group
-          if: always()
+          if: ${{ (github.event_name == 'workflow_dispatch' && inputs.deleteAzureResources) }}
           id: delete-resource-group
           run: |
             echo "delete... " $singleResourceGroup

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -268,36 +268,18 @@ jobs:
                     --name single \
                     --parameters @rhel-jboss-templates/eap74-rhel8-payg/src/test/parameters-test-single.json \
                     --template-file rhel-jboss-templates/eap74-rhel8-payg/mainTemplate.json
-            - name: Setup public IP
-              id: setup_public_lb
+            - name: Get public IP
+              id: get_public_ip
               uses: azure/CLI@v1
               with:
                 azcliversion: ${{ env.azCliVersion }}
                 inlineScript: |
-                    # Create NSG rule to allow inbound traffic to port 9990
-                    az network nsg rule create -g ${{ env.singleResourceGroup }} --nsg-name ${{ env.nsgName }} -n rule_9990 --priority 100 \
-                      --source-address-prefixes '*' --source-port-ranges '*' \
-                      --destination-address-prefixes '*' --destination-port-ranges 9990 8080 --access Allow \
-                      --protocol '*' --description "allow 9990,8080"
-                    # Create public IP
-                    az network public-ip create --name ${{ env.testPubIpName }} --resource-group ${{ env.singleResourceGroup }}
-                    # Query VM NIC name
-                    nicId=$(az vm nic list --vm-name $vmName --resource-group $singleResourceGroup --query [0].id -o tsv)
-                    nicName=$(az vm nic show --vm-name $vmName --resource-group $singleResourceGroup --nic $nicId --query name -o tsv)
-                    # Query VM NIC ipconfig name
-                    configName=$(az network nic ip-config list --nic-name $nicName --resource-group $singleResourceGroup --query [0].name -o tsv)
-                    # Update configuration, associate the public IP to the VM
-                    az network nic ip-config update \
-                      --name $configName \
-                      --nic-name $nicName \
-                      --resource-group ${{ env.singleResourceGroup }} \
-                      --public-ip-address ${{ env.testPubIpName }}
                     # Query public IP for later use
-                    publicip=$(az network public-ip show --name ${{ env.testPubIpName }} --resource-group $singleResourceGroup --query ipAddress -o tsv)
+                    publicip=$(az network public-ip show --name 'vmip' --resource-group $singleResourceGroup --query ipAddress -o tsv)
                     echo "##[set-output name=publicip;]${publicip}"
             - name: Verify console is accessible
               run: |
-                publicip=${{steps.setup_public_lb.outputs.publicip}}
+                publicip=${{steps.get_public_ip.outputs.publicip}}
                 echo "publicip: " $publicip
                 CURL_RETRY_PARMS="--connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused"
 

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -275,7 +275,7 @@ jobs:
                 azcliversion: ${{ env.azCliVersion }}
                 inlineScript: |
                     # Query public IP for later use
-                    publicip=$(az network public-ip show --name 'vmip' --resource-group $singleResourceGroup --query ipAddress -o tsv)
+                    publicip=$(az network public-ip show --name 'jbosseapVm-ip' --resource-group $singleResourceGroup --query ipAddress -o tsv)
                     echo "##[set-output name=publicip;]${publicip}"
             - name: Verify console is accessible
               run: |

--- a/.github/workflows/validate-payg-vmss.yaml
+++ b/.github/workflows/validate-payg-vmss.yaml
@@ -14,10 +14,11 @@ on:
         - mysql
         - postgresql
         - none
-      isForDemo:
-        description: 'If set to true, resources will not be deleted'
+      deleteAzureResources:
+        description: 'Delete Azure resources at the end'
         required: true
-        default: 'false'
+        type: boolean
+        default: true
 
 env:
     azCliVersion: 2.30.0
@@ -51,7 +52,6 @@ env:
 jobs:
     preflight:
         outputs:
-          isForDemo: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.isForDemo }}
           artifactName: ${{steps.build.outputs.artifactName}}
         runs-on: ubuntu-latest
         steps:
@@ -64,12 +64,6 @@ jobs:
                 offerName: ${{ env.offerName }}
                 token: ${{ secrets.GITHUB_TOKEN }}
                 workflowType: "validate"
-            - name: Setup environment variables
-              id: setup-env-variables-based-on-dispatch-event
-              run: |
-                isForDemo=${{ github.event.inputs.isForDemo }}
-                echo "##[set-output name=isForDemo;]${isForDemo}"
-                echo "isForDemo=${isForDemo}" >> "$GITHUB_ENV"
     deploy-vmss:
         needs: preflight
         runs-on: ubuntu-latest
@@ -301,7 +295,7 @@ jobs:
                 fi
                 exit 0
             - name: Unregister before deleting resources
-              if: ${{ needs.preflight.outputs.isForDemo == 'false' }}
+              if: ${{ (github.event_name == 'workflow_dispatch' && inputs.deleteAzureResources) }}
               uses: azure/CLI@v1
               with:
                 azcliversion: ${{ env.azCliVersion }}
@@ -327,7 +321,7 @@ jobs:
           with:
             path: rhel-jboss-templates
         - name: Delete Resource Group
-          if: always()
+          if: ${{ (github.event_name == 'workflow_dispatch' && inputs.deleteAzureResources) }}
           id: delete-resource-group
           run: |
             echo "delete... " $vmssResourceGroup

--- a/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
@@ -313,7 +313,7 @@ resource vmName_resource 'Microsoft.Compute/virtualMachines@${azure.apiVersionFo
       ]
       networkInterfaceConfigurations: [
         {
-          name: nicName
+          name: nicName_var
           properties: {
             primary: true
             ipConfigurations: [

--- a/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
@@ -264,13 +264,16 @@ resource nicName 'Microsoft.Network/networkInterfaces@${azure.apiVersionForNetwo
           subnet: {
             id: resourceId(virtualNetworkResourceGroupName, 'Microsoft.Network/virtualNetworks/subnets/', virtualNetworkName, subnetName)
           }
+          publicIPAddress: {
+            id: resourceId('Microsoft.Network/publicIPAddresses', vmPublicIPAddressName)
+          }
         }
       }
     ]
   }
   dependsOn: [
     virtualNetworkName_resource
-
+    vmPublicIP
   ]
 }
 
@@ -309,29 +312,6 @@ resource vmName_resource 'Microsoft.Compute/virtualMachines@${azure.apiVersionFo
       networkInterfaces: [
         {
           id: nicName.id
-        }
-      ]
-      networkInterfaceConfigurations: [
-        {
-          name: nicName_var
-          properties: {
-            primary: true
-            ipConfigurations: [
-              {
-                name: 'ipconfig1'
-                properties: {
-                  publicIPAddressConfiguration: {
-                    name: 'vmPublicIpConfig'
-                    properties: {
-                      publicIPAddress: {
-                        id: resourceId('Microsoft.Network/publicIPAddresses', vmPublicIPAddressName)
-                      }
-                    }
-                  }
-                }
-              }
-            ]
-          }
         }
       ]
     }

--- a/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
@@ -311,26 +311,35 @@ resource vmName_resource 'Microsoft.Compute/virtualMachines@${azure.apiVersionFo
           id: nicName.id
         }
       ]
-    }
-    ipConfigurations: [
-      {
-        name: 'ipconfig1'
-        properties: {
-          privateIPAllocationMethod: 'Dynamic'
-          subnet: {
-            id: resourceId(virtualNetworkResourceGroupName, 'Microsoft.Network/virtualNetworks/subnets', virtualNetworkName, subnetName)
-          }
-          publicIPAddressConfiguration: {
-                name: 'vmPublicIpConfig'
+      networkInterfaceConfigurations: [
+        {
+          name: nicName
+          properties: {
+            primary: true
+            ipConfigurations: [
+              {
+                name: 'ipconfig1'
                 properties: {
-                  publicIPAddress: {
-                    id: resourceId('Microsoft.Network/publicIPAddresses', vmPublicIPAddressName)
+                  privateIPAllocationMethod: 'Dynamic'
+                  subnet: {
+                    id: resourceId(virtualNetworkResourceGroupName, 'Microsoft.Network/virtualNetworks/subnets', virtualNetworkName, subnetName)
+                  }
+                  publicIPAddressConfiguration: {
+                    name: 'vmPublicIpConfig'
+                    properties: {
+                      publicIPAddress: {
+                        id: resourceId('Microsoft.Network/publicIPAddresses', vmPublicIPAddressName)
+                      }
+                    }
                   }
                 }
+              }
+            ]
           }
         }
-      }
-    ]
+      ]
+    }
+
     diagnosticsProfile: ((bootDiagnostics == 'on') ? json('{"bootDiagnostics": {"enabled": true,"storageUri": "${reference(resourceId(storageAccountResourceGroupName, 'Microsoft.Storage/storageAccounts/', bootStorageName_var), '2021-06-01').primaryEndpoints.blob}"}}') : json('{"bootDiagnostics": {"enabled": false}}'))
   }
   dependsOn: [

--- a/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
@@ -140,7 +140,6 @@ param dbPassword string = newGuid()
 
 param guidValue string = take(replace(newGuid(), '-', ''), 6)
 
-var ipconfigName = 'ipconfig1'
 var nicName_var = '${uniqueString(resourceGroup().id)}-nic'
 var networkSecurityGroupName_var = 'jbosseap-nsg'
 var bootDiagnosticsCheck = ((storageNewOrExisting == 'New') && (bootDiagnostics == 'on'))
@@ -259,7 +258,7 @@ resource nicName 'Microsoft.Network/networkInterfaces@${azure.apiVersionForNetwo
     }
     ipConfigurations: [
       {
-        name: ipconfigName
+        name: 'ipconfig1'
         properties: {
           privateIPAllocationMethod: 'Dynamic'
           subnet: {

--- a/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
@@ -140,6 +140,7 @@ param dbPassword string = newGuid()
 
 param guidValue string = take(replace(newGuid(), '-', ''), 6)
 
+var ipconfigName = 'ipconfig1'
 var nicName_var = '${uniqueString(resourceGroup().id)}-nic'
 var networkSecurityGroupName_var = 'jbosseap-nsg'
 var bootDiagnosticsCheck = ((storageNewOrExisting == 'New') && (bootDiagnostics == 'on'))
@@ -258,7 +259,7 @@ resource nicName 'Microsoft.Network/networkInterfaces@${azure.apiVersionForNetwo
     }
     ipConfigurations: [
       {
-        name: 'ipconfig1'
+        name: ipconfigName
         properties: {
           privateIPAllocationMethod: 'Dynamic'
           subnet: {

--- a/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
@@ -8,7 +8,7 @@ param vmName string= 'jbosseapVm'
 param adminUsername string = 'jbossuser'
 
 @description('Public IP Name for the VM')
-param vmPublicIPAddressName string = 'vmip'
+param vmPublicIPAddressName string = 'jbosseapVm-ip'
 
 @description('DNS prefix for VM')
 param dnsNameforVM string = 'jbossvm${take(uniqueString(utcNow()), 6)}'

--- a/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
@@ -315,7 +315,6 @@ resource vmName_resource 'Microsoft.Compute/virtualMachines@${azure.apiVersionFo
         }
       ]
     }
-
     diagnosticsProfile: ((bootDiagnostics == 'on') ? json('{"bootDiagnostics": {"enabled": true,"storageUri": "${reference(resourceId(storageAccountResourceGroupName, 'Microsoft.Storage/storageAccounts/', bootStorageName_var), '2021-06-01').primaryEndpoints.blob}"}}') : json('{"bootDiagnostics": {"enabled": false}}'))
   }
   dependsOn: [

--- a/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-byos/src/main/bicep/mainTemplate.bicep
@@ -320,10 +320,6 @@ resource vmName_resource 'Microsoft.Compute/virtualMachines@${azure.apiVersionFo
               {
                 name: 'ipconfig1'
                 properties: {
-                  privateIPAllocationMethod: 'Dynamic'
-                  subnet: {
-                    id: resourceId(virtualNetworkResourceGroupName, 'Microsoft.Network/virtualNetworks/subnets', virtualNetworkName, subnetName)
-                  }
                   publicIPAddressConfiguration: {
                     name: 'vmPublicIpConfig'
                     properties: {

--- a/eap74-rhel8-payg/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-payg/src/main/bicep/mainTemplate.bicep
@@ -7,6 +7,12 @@ param vmName string = 'jbosseapVm'
 @description('Linux VM user account name')
 param adminUsername string = 'jbossuser'
 
+@description('Public IP Name for the VM')
+param vmPublicIPAddressName string = 'vmip'
+
+@description('DNS prefix for VM')
+param dnsNameforVM string = 'jbossvm${take(uniqueString(utcNow()), 6)}'
+
 @description('Type of authentication to use on the Virtual Machine')
 @allowed([
   'password'
@@ -205,6 +211,28 @@ resource bootStorageName 'Microsoft.Storage/storageAccounts@${azure.apiVersionFo
 resource networkSecurityGroupName 'Microsoft.Network/networkSecurityGroups@${azure.apiVersionForNetworkSecurityGroups}' = {
   name: networkSecurityGroupName_var
   location: location
+  properties: {
+    securityRules: [
+      {
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          sourceAddressPrefix: 'Internet'
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 510
+          direction: 'Inbound'
+          destinationPortRanges: [
+            '80'
+            '443'
+            '9990'
+            '8080'
+          ]
+        }
+        name: 'ALLOW_HTTP_ACCESS'
+      }
+    ]
+  }
 }
 
 resource virtualNetworkName_resource 'Microsoft.Network/virtualNetworks@${azure.apiVersionForVirtualNetworks}' = if (virtualNetworkNewOrExisting == 'new') {
@@ -242,6 +270,9 @@ resource nicName 'Microsoft.Network/networkInterfaces@${azure.apiVersionForNetwo
           privateIPAllocationMethod: 'Dynamic'
           subnet: {
             id: resourceId(virtualNetworkResourceGroupName, 'Microsoft.Network/virtualNetworks/subnets/', virtualNetworkName, subnetName)
+          }
+          publicIPAddress: {
+            id: resourceId('Microsoft.Network/publicIPAddresses', vmPublicIPAddressName)
           }
         }
       }
@@ -306,8 +337,22 @@ resource vmName_resource 'Microsoft.Compute/virtualMachines@${azure.apiVersionFo
   dependsOn: [
     bootStorageName
     networkSecurityGroupName
-
+    vmPublicIP
   ]
+}
+
+resource vmPublicIP 'Microsoft.Network/publicIPAddresses@${azure.apiVersionForPublicIPAddresses}' = {
+  name: vmPublicIPAddressName
+  sku: {
+    name: 'Standard'
+  }
+  location: location
+  properties: {
+    publicIPAllocationMethod: 'Static'
+    dnsSettings: {
+      domainNameLabel: dnsNameforVM
+    }
+  }
 }
 
 module dbConnectionStartPid './modules/_pids/_pid.bicep' = if (enableDB) {

--- a/eap74-rhel8-payg/src/main/bicep/mainTemplate.bicep
+++ b/eap74-rhel8-payg/src/main/bicep/mainTemplate.bicep
@@ -8,7 +8,7 @@ param vmName string = 'jbosseapVm'
 param adminUsername string = 'jbossuser'
 
 @description('Public IP Name for the VM')
-param vmPublicIPAddressName string = 'vmip'
+param vmPublicIPAddressName string = 'jbosseapVm-ip'
 
 @description('DNS prefix for VM')
 param dnsNameforVM string = 'jbossvm${take(uniqueString(utcNow()), 6)}'

--- a/pom.xml
+++ b/pom.xml
@@ -41,12 +41,12 @@
              check https://github.com/azure-javaee/azure-javaee-iaas/blob/b7b966b502212c40f23fd391a088da6a9b20bdc3/arm-parent/pom.xml#L361  -->
         <template.azure-common.properties.url>file:///${rootmoduledir}/utilities/azure-common.properties</template.azure-common.properties.url>
 
-        <version.eap74-rhel8-byos>1.0.14</version.eap74-rhel8-byos>
-        <version.eap74-rhel8-byos-multivm>1.0.22</version.eap74-rhel8-byos-multivm>
-        <version.eap74-rhel8-byos-vmss>1.0.20</version.eap74-rhel8-byos-vmss>
-        <version.eap74-rhel8-payg>1.0.24</version.eap74-rhel8-payg>
-        <version.eap74-rhel8-payg-multivm>1.0.24</version.eap74-rhel8-payg-multivm>
-        <version.eap74-rhel8-payg-vmss>1.0.23</version.eap74-rhel8-payg-vmss>
+        <version.eap74-rhel8-byos>1.0.15</version.eap74-rhel8-byos>
+        <version.eap74-rhel8-byos-multivm>1.0.23</version.eap74-rhel8-byos-multivm>
+        <version.eap74-rhel8-byos-vmss>1.0.21</version.eap74-rhel8-byos-vmss>
+        <version.eap74-rhel8-payg>1.0.25</version.eap74-rhel8-payg>
+        <version.eap74-rhel8-payg-multivm>1.0.25</version.eap74-rhel8-payg-multivm>
+        <version.eap74-rhel8-payg-vmss>1.0.24</version.eap74-rhel8-payg-vmss>
         <version.eap-aro>1.0.14</version.eap-aro>
     </properties>
 


### PR DESCRIPTION
## Context 
Refer to [em-4767](https://dev.azure.com/edburns-msft/Open%20Standard%20Enterprise%20Java%20(Java%20EE)%20on%20Azure/_workitems/edit/4767) and [COMPAZ-45](https://issues.redhat.com/browse/COMPAZ-45) 


## Updates
1. Now when users create single vm offer, it will create a publicIp and a networkSecurityGroup rule.
1. Refactor github workflows
  - Replace `isForDemo` input with `deleteAzureResources`.
  - Remove public IP setup.








