### PR TITLE
BugFix: Redhat Jboss Offers can' be redeployed with the same resource group as before with different region in the same subscription

### DIFF
--- a/eap74-rhel8-byos-multivm/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
+++ b/eap74-rhel8-byos-multivm/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
@@ -15,11 +15,11 @@
 */
 
 param location string
+param name_deploymentScriptContributorRoleAssignmentName string = newGuid()
 
 // https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
 var const_roleDefinitionIdOfContributor = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
-var name_deploymentScriptUserDefinedManagedIdentity = 'jboss-eap-vm-deployment-script-user-defined-managed-itentity'
-var name_deploymentScriptContributorRoleAssignmentName = guid('${resourceGroup().id}${name_deploymentScriptUserDefinedManagedIdentity}Deployment Script')
+var name_deploymentScriptUserDefinedManagedIdentity = 'jboss-eap-vm-deployment-script-user-defined-managed-itentity-${substring(uniqueString(name_deploymentScriptContributorRoleAssignmentName),0,5)}'
 
 // UAMI for deployment script
 resource uamiForDeploymentScript 'Microsoft.ManagedIdentity/userAssignedIdentities@${azure.apiVersionForIdentity}' = {

--- a/eap74-rhel8-byos-vmss/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
+++ b/eap74-rhel8-byos-vmss/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
@@ -15,11 +15,11 @@
 */
 
 param location string
+param name_deploymentScriptContributorRoleAssignmentName string = newGuid()
 
 // https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
 var const_roleDefinitionIdOfContributor = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
-var name_deploymentScriptUserDefinedManagedIdentity = 'jboss-eap-vm-deployment-script-user-defined-managed-itentity'
-var name_deploymentScriptContributorRoleAssignmentName = guid('${resourceGroup().id}${name_deploymentScriptUserDefinedManagedIdentity}Deployment Script')
+var name_deploymentScriptUserDefinedManagedIdentity = 'jboss-eap-vm-deployment-script-user-defined-managed-itentity-${substring(uniqueString(name_deploymentScriptContributorRoleAssignmentName),0,5)}'
 
 // UAMI for deployment script
 resource uamiForDeploymentScript 'Microsoft.ManagedIdentity/userAssignedIdentities@${azure.apiVersionForIdentity}' = {

--- a/eap74-rhel8-byos/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
+++ b/eap74-rhel8-byos/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
@@ -15,11 +15,11 @@
 */
 
 param location string
+param name_deploymentScriptContributorRoleAssignmentName string = newGuid()
 
 // https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
 var const_roleDefinitionIdOfContributor = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
-var name_deploymentScriptUserDefinedManagedIdentity = 'jboss-eap-vm-deployment-script-user-defined-managed-itentity'
-var name_deploymentScriptContributorRoleAssignmentName = guid('${resourceGroup().id}${name_deploymentScriptUserDefinedManagedIdentity}Deployment Script')
+var name_deploymentScriptUserDefinedManagedIdentity = 'jboss-eap-vm-deployment-script-user-defined-managed-itentity-${substring(uniqueString(name_deploymentScriptContributorRoleAssignmentName),0,5)}'
 
 // UAMI for deployment script
 resource uamiForDeploymentScript 'Microsoft.ManagedIdentity/userAssignedIdentities@${azure.apiVersionForIdentity}' = {

--- a/eap74-rhel8-payg-multivm/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
+++ b/eap74-rhel8-payg-multivm/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
@@ -15,11 +15,11 @@
 */
 
 param location string
+param name_deploymentScriptContributorRoleAssignmentName string = newGuid()
 
 // https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
 var const_roleDefinitionIdOfContributor = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
-var name_deploymentScriptUserDefinedManagedIdentity = 'jboss-eap-vm-deployment-script-user-defined-managed-itentity'
-var name_deploymentScriptContributorRoleAssignmentName = guid('${resourceGroup().id}${name_deploymentScriptUserDefinedManagedIdentity}Deployment Script')
+var name_deploymentScriptUserDefinedManagedIdentity = 'jboss-eap-vm-deployment-script-user-defined-managed-itentity-${substring(uniqueString(name_deploymentScriptContributorRoleAssignmentName),0,5)}'
 
 // UAMI for deployment script
 resource uamiForDeploymentScript 'Microsoft.ManagedIdentity/userAssignedIdentities@${azure.apiVersionForIdentity}' = {

--- a/eap74-rhel8-payg-vmss/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
+++ b/eap74-rhel8-payg-vmss/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
@@ -15,11 +15,11 @@
 */
 
 param location string
+param name_deploymentScriptContributorRoleAssignmentName string = newGuid()
 
 // https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
 var const_roleDefinitionIdOfContributor = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
-var name_deploymentScriptUserDefinedManagedIdentity = 'jboss-eap-vm-deployment-script-user-defined-managed-itentity'
-var name_deploymentScriptContributorRoleAssignmentName = guid('${resourceGroup().id}${name_deploymentScriptUserDefinedManagedIdentity}Deployment Script')
+var name_deploymentScriptUserDefinedManagedIdentity = 'jboss-eap-vm-deployment-script-user-defined-managed-itentity-${substring(uniqueString(name_deploymentScriptContributorRoleAssignmentName),0,5)}'
 
 // UAMI for deployment script
 resource uamiForDeploymentScript 'Microsoft.ManagedIdentity/userAssignedIdentities@${azure.apiVersionForIdentity}' = {

--- a/eap74-rhel8-payg/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
+++ b/eap74-rhel8-payg/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
@@ -15,11 +15,11 @@
 */
 
 param location string
+param name_deploymentScriptContributorRoleAssignmentName string = newGuid()
 
 // https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
 var const_roleDefinitionIdOfContributor = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
-var name_deploymentScriptUserDefinedManagedIdentity = 'jboss-eap-vm-deployment-script-user-defined-managed-itentity'
-var name_deploymentScriptContributorRoleAssignmentName = guid('${resourceGroup().id}${name_deploymentScriptUserDefinedManagedIdentity}Deployment Script')
+var name_deploymentScriptUserDefinedManagedIdentity = 'jboss-eap-vm-deployment-script-user-defined-managed-itentity-${substring(uniqueString(name_deploymentScriptContributorRoleAssignmentName),0,5)}'
 
 // UAMI for deployment script
 resource uamiForDeploymentScript 'Microsoft.ManagedIdentity/userAssignedIdentities@${azure.apiVersionForIdentity}' = {

--- a/pom.xml
+++ b/pom.xml
@@ -41,12 +41,12 @@
              check https://github.com/azure-javaee/azure-javaee-iaas/blob/b7b966b502212c40f23fd391a088da6a9b20bdc3/arm-parent/pom.xml#L361  -->
         <template.azure-common.properties.url>file:///${rootmoduledir}/utilities/azure-common.properties</template.azure-common.properties.url>
 
-        <version.eap74-rhel8-byos>1.0.13</version.eap74-rhel8-byos>
-        <version.eap74-rhel8-byos-multivm>1.0.21</version.eap74-rhel8-byos-multivm>
-        <version.eap74-rhel8-byos-vmss>1.0.19</version.eap74-rhel8-byos-vmss>
-        <version.eap74-rhel8-payg>1.0.23</version.eap74-rhel8-payg>
-        <version.eap74-rhel8-payg-multivm>1.0.23</version.eap74-rhel8-payg-multivm>
-        <version.eap74-rhel8-payg-vmss>1.0.22</version.eap74-rhel8-payg-vmss>
+        <version.eap74-rhel8-byos>1.0.14</version.eap74-rhel8-byos>
+        <version.eap74-rhel8-byos-multivm>1.0.22</version.eap74-rhel8-byos-multivm>
+        <version.eap74-rhel8-byos-vmss>1.0.20</version.eap74-rhel8-byos-vmss>
+        <version.eap74-rhel8-payg>1.0.24</version.eap74-rhel8-payg>
+        <version.eap74-rhel8-payg-multivm>1.0.24</version.eap74-rhel8-payg-multivm>
+        <version.eap74-rhel8-payg-vmss>1.0.23</version.eap74-rhel8-payg-vmss>
         <version.eap-aro>1.0.14</version.eap-aro>
     </properties>
 


### PR DESCRIPTION
## Context
If I try to do following steps, it will fail.
Step 1. Deploy jboss offer in resource group `rg-a` and region `east us`
Step 2. Delete resource group `rg-a`
Step 3. Deploy jboss offer in resource group `rg-a` and region `west us` 

And this PR is used to fix this bug.


## Test 
Test with preview offers have passed.

