### PR TITLE
Update Regex Pattern for Valid Code Repository URL Validation

### DIFF
--- a/eap-aro/src/main/arm/createUiDefinition.json
+++ b/eap-aro/src/main/arm/createUiDefinition.json
@@ -294,8 +294,8 @@
                                 "toolTip": "The Git source code repository URL.",
                                 "constraints": {
                                     "required": true,
-                                    "regex": "https?:\/\/github\\.com\/[a-zA-Z0-9_\\-]*\/[a-zA-Z0-9_\\-]*",
-                                    "validationMessage": "The value must be a valid container image path. For example, https://github.com/jboss-developer/jboss-eap-quickstarts"
+                                    "regex": "https?:\\/\\/[a-zA-Z0-9._\\-]+(\\/[a-zA-Z0-9_\\-]+)+",
+                                    "validationMessage": "The value must be a valid code repository URL. For example, https://github.com/jboss-developer/jboss-eap-quickstarts"
                                 },
                                 "visible": "[equals(steps('Application').appSrcInfo.appOption, '1')]"
                             },

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.eap74-rhel8-payg>1.0.25</version.eap74-rhel8-payg>
         <version.eap74-rhel8-payg-multivm>1.0.26</version.eap74-rhel8-payg-multivm>
         <version.eap74-rhel8-payg-vmss>1.0.25</version.eap74-rhel8-payg-vmss>
-        <version.eap-aro>1.0.16</version.eap-aro>
+        <version.eap-aro>1.0.17</version.eap-aro>
     </properties>
 
     <modules>


### PR DESCRIPTION
## Changes
This PR updates the regex pattern used for validating code repository URLs. The previous regex was limited to GitHub URLs only, while the new regex is more flexible and allows for a broader range of code repository URLs.