### PR TITLE
Exclude arm64 cpu based vm sizes

### DIFF
--- a/eap74-rhel8-byos-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-byos-multivm/src/main/arm/createUiDefinition.json
@@ -40,7 +40,7 @@
             {
                 "name": "invalidVMSizeInfo",
                 "type": "Microsoft.Common.InfoBox",
-                "visible": "[contains(steps('ClusterConfig').vmSizeSelect,'p')]",
+                "visible": "[contains(basics('vmSize').vmSizeSelect,'p')]",
                 "options": {
                     "icon": "Error",
                     "text": "The VM size you selected includes the feature letter 'p', indicating it uses ARM CPUs. ARM platform is not supported. Please select a different VM size. For more information, refer to the <a href='https://learn.microsoft.com/azure/virtual-machines/vm-naming-conventions' target='_blank'>Azure virtual machine sizes naming conventions</a>."

--- a/eap74-rhel8-byos-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-byos-multivm/src/main/arm/createUiDefinition.json
@@ -29,8 +29,22 @@
                     "Standard_F4S_v2",
                     "Standard_F8S_v2" 
                 ],
+                "constraints": {
+                    "excludedSizes": [
+                        ${azure.armBased.vmSize.list}
+                    ]
+                },
                 "osPlatform": "Linux",
                 "count": "1"
+            },
+            {
+                "name": "invalidVMSizeInfo",
+                "type": "Microsoft.Common.InfoBox",
+                "visible": "[contains(steps('ClusterConfig').vmSizeSelect,'p')]",
+                "options": {
+                    "icon": "Error",
+                    "text": "The VM size you selected includes the feature letter 'p', indicating it uses ARM CPUs. ARM platform is not supported. Please select a different VM size. For more information, refer to the <a href='https://learn.microsoft.com/azure/virtual-machines/vm-naming-conventions' target='_blank'>Azure virtual machine sizes naming conventions</a>."
+                }
             },
             {
                 "name": "jdkVersion",

--- a/eap74-rhel8-byos-vmss/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-byos-vmss/src/main/arm/createUiDefinition.json
@@ -20,8 +20,22 @@
                     "Standard_F4S_v2",
                     "Standard_F8S_v2"
                 ],
+                "constraints": {
+                    "excludedSizes": [
+                        ${azure.armBased.vmSize.list}
+                    ]
+                },
                 "osPlatform": "Linux",
                 "count": "1"
+            },
+            {
+                "name": "invalidVMSizeInfo",
+                "type": "Microsoft.Common.InfoBox",
+                "visible": "[contains(steps('ClusterConfig').vmSizeSelect,'p')]",
+                "options": {
+                    "icon": "Error",
+                    "text": "The VM size you selected includes the feature letter 'p', indicating it uses ARM CPUs. ARM platform is not supported. Please select a different VM size. For more information, refer to the <a href='https://learn.microsoft.com/azure/virtual-machines/vm-naming-conventions' target='_blank'>Azure virtual machine sizes naming conventions</a>."
+                }
             },
             {
                 "name": "jdkVersion",

--- a/eap74-rhel8-byos-vmss/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-byos-vmss/src/main/arm/createUiDefinition.json
@@ -31,7 +31,7 @@
             {
                 "name": "invalidVMSizeInfo",
                 "type": "Microsoft.Common.InfoBox",
-                "visible": "[contains(steps('ClusterConfig').vmSizeSelect,'p')]",
+                "visible": "[contains(basics('vmSize').vmSizeSelect,'p')]",
                 "options": {
                     "icon": "Error",
                     "text": "The VM size you selected includes the feature letter 'p', indicating it uses ARM CPUs. ARM platform is not supported. Please select a different VM size. For more information, refer to the <a href='https://learn.microsoft.com/azure/virtual-machines/vm-naming-conventions' target='_blank'>Azure virtual machine sizes naming conventions</a>."

--- a/eap74-rhel8-byos/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-byos/src/main/arm/createUiDefinition.json
@@ -20,8 +20,22 @@
                     "Standard_F4S_v2",
                     "Standard_F8S_v2" 
                 ],
+                "constraints": {
+                    "excludedSizes": [
+                        ${azure.armBased.vmSize.list}
+                    ]
+                },
                 "osPlatform": "Linux",
                 "count": "1"
+            },
+            {
+                "name": "invalidVMSizeInfo",
+                "type": "Microsoft.Common.InfoBox",
+                "visible": "[contains(steps('ClusterConfig').vmSizeSelect,'p')]",
+                "options": {
+                    "icon": "Error",
+                    "text": "The VM size you selected includes the feature letter 'p', indicating it uses ARM CPUs. ARM platform is not supported. Please select a different VM size. For more information, refer to the <a href='https://learn.microsoft.com/azure/virtual-machines/vm-naming-conventions' target='_blank'>Azure virtual machine sizes naming conventions</a>."
+                }
             },
             {
                 "name": "jdkVersion",

--- a/eap74-rhel8-byos/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-byos/src/main/arm/createUiDefinition.json
@@ -31,7 +31,7 @@
             {
                 "name": "invalidVMSizeInfo",
                 "type": "Microsoft.Common.InfoBox",
-                "visible": "[contains(steps('ClusterConfig').vmSizeSelect,'p')]",
+                "visible": "[contains(basics('vmSize').vmSizeSelect,'p')]",
                 "options": {
                     "icon": "Error",
                     "text": "The VM size you selected includes the feature letter 'p', indicating it uses ARM CPUs. ARM platform is not supported. Please select a different VM size. For more information, refer to the <a href='https://learn.microsoft.com/azure/virtual-machines/vm-naming-conventions' target='_blank'>Azure virtual machine sizes naming conventions</a>."

--- a/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
@@ -29,8 +29,22 @@
                     "Standard_F4S_v2",
                     "Standard_F8S_v2"
                 ],
+                "constraints": {
+                    "excludedSizes": [
+                        ${azure.armBased.vmSize.list}
+                    ]
+                },
                 "osPlatform": "Linux",
                 "count": "1"
+            },
+            {
+                "name": "invalidVMSizeInfo",
+                "type": "Microsoft.Common.InfoBox",
+                "visible": "[contains(steps('ClusterConfig').vmSizeSelect,'p')]",
+                "options": {
+                    "icon": "Error",
+                    "text": "The VM size you selected includes the feature letter 'p', indicating it uses ARM CPUs. ARM platform is not supported. Please select a different VM size. For more information, refer to the <a href='https://learn.microsoft.com/azure/virtual-machines/vm-naming-conventions' target='_blank'>Azure virtual machine sizes naming conventions</a>."
+                }
             },
             {
                 "name": "jdkVersion",

--- a/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-multivm/src/main/arm/createUiDefinition.json
@@ -40,7 +40,7 @@
             {
                 "name": "invalidVMSizeInfo",
                 "type": "Microsoft.Common.InfoBox",
-                "visible": "[contains(steps('ClusterConfig').vmSizeSelect,'p')]",
+                "visible": "[contains(basics('vmSize').vmSizeSelect,'p')]",
                 "options": {
                     "icon": "Error",
                     "text": "The VM size you selected includes the feature letter 'p', indicating it uses ARM CPUs. ARM platform is not supported. Please select a different VM size. For more information, refer to the <a href='https://learn.microsoft.com/azure/virtual-machines/vm-naming-conventions' target='_blank'>Azure virtual machine sizes naming conventions</a>."

--- a/eap74-rhel8-payg-vmss/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-vmss/src/main/arm/createUiDefinition.json
@@ -20,8 +20,22 @@
                     "Standard_F4S_v2",
                     "Standard_F8S_v2" 
                 ],
+                "constraints": {
+                    "excludedSizes": [
+                        ${azure.armBased.vmSize.list}
+                    ]
+                },
                 "osPlatform": "Linux",
                 "count": "1"
+            },
+            {
+                "name": "invalidVMSizeInfo",
+                "type": "Microsoft.Common.InfoBox",
+                "visible": "[contains(steps('ClusterConfig').vmSizeSelect,'p')]",
+                "options": {
+                    "icon": "Error",
+                    "text": "The VM size you selected includes the feature letter 'p', indicating it uses ARM CPUs. ARM platform is not supported. Please select a different VM size. For more information, refer to the <a href='https://learn.microsoft.com/azure/virtual-machines/vm-naming-conventions' target='_blank'>Azure virtual machine sizes naming conventions</a>."
+                }
             },
             {
                 "name": "jdkVersion",

--- a/eap74-rhel8-payg-vmss/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg-vmss/src/main/arm/createUiDefinition.json
@@ -31,7 +31,7 @@
             {
                 "name": "invalidVMSizeInfo",
                 "type": "Microsoft.Common.InfoBox",
-                "visible": "[contains(steps('ClusterConfig').vmSizeSelect,'p')]",
+                "visible": "[contains(basics('vmSize').vmSizeSelect,'p')]",
                 "options": {
                     "icon": "Error",
                     "text": "The VM size you selected includes the feature letter 'p', indicating it uses ARM CPUs. ARM platform is not supported. Please select a different VM size. For more information, refer to the <a href='https://learn.microsoft.com/azure/virtual-machines/vm-naming-conventions' target='_blank'>Azure virtual machine sizes naming conventions</a>."

--- a/eap74-rhel8-payg/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg/src/main/arm/createUiDefinition.json
@@ -20,8 +20,22 @@
                     "Standard_F4S_v2",
                     "Standard_F8S_v2" 
                 ],
+                "constraints": {
+                    "excludedSizes": [
+                        ${azure.armBased.vmSize.list}
+                    ]
+                },
                 "osPlatform": "Linux",
                 "count": "1"
+            },
+            {
+                "name": "invalidVMSizeInfo",
+                "type": "Microsoft.Common.InfoBox",
+                "visible": "[contains(steps('ClusterConfig').vmSizeSelect,'p')]",
+                "options": {
+                    "icon": "Error",
+                    "text": "The VM size you selected includes the feature letter 'p', indicating it uses ARM CPUs. ARM platform is not supported. Please select a different VM size. For more information, refer to the <a href='https://learn.microsoft.com/azure/virtual-machines/vm-naming-conventions' target='_blank'>Azure virtual machine sizes naming conventions</a>."
+                }
             },
             {
                 "name": "jdkVersion",

--- a/eap74-rhel8-payg/src/main/arm/createUiDefinition.json
+++ b/eap74-rhel8-payg/src/main/arm/createUiDefinition.json
@@ -31,7 +31,7 @@
             {
                 "name": "invalidVMSizeInfo",
                 "type": "Microsoft.Common.InfoBox",
-                "visible": "[contains(steps('ClusterConfig').vmSizeSelect,'p')]",
+                "visible": "[contains(basics('vmSize').vmSizeSelect,'p')]",
                 "options": {
                     "icon": "Error",
                     "text": "The VM size you selected includes the feature letter 'p', indicating it uses ARM CPUs. ARM platform is not supported. Please select a different VM size. For more information, refer to the <a href='https://learn.microsoft.com/azure/virtual-machines/vm-naming-conventions' target='_blank'>Azure virtual machine sizes naming conventions</a>."

--- a/pom.xml
+++ b/pom.xml
@@ -41,12 +41,12 @@
              check https://github.com/azure-javaee/azure-javaee-iaas/blob/b7b966b502212c40f23fd391a088da6a9b20bdc3/arm-parent/pom.xml#L361  -->
         <template.azure-common.properties.url>file:///${rootmoduledir}/utilities/azure-common.properties</template.azure-common.properties.url>
 
-        <version.eap74-rhel8-byos>1.0.15</version.eap74-rhel8-byos>
-        <version.eap74-rhel8-byos-multivm>1.0.24</version.eap74-rhel8-byos-multivm>
-        <version.eap74-rhel8-byos-vmss>1.0.22</version.eap74-rhel8-byos-vmss>
-        <version.eap74-rhel8-payg>1.0.26</version.eap74-rhel8-payg>
-        <version.eap74-rhel8-payg-multivm>1.0.27</version.eap74-rhel8-payg-multivm>
-        <version.eap74-rhel8-payg-vmss>1.0.26</version.eap74-rhel8-payg-vmss>
+        <version.eap74-rhel8-byos>1.0.16</version.eap74-rhel8-byos>
+        <version.eap74-rhel8-byos-multivm>1.0.25</version.eap74-rhel8-byos-multivm>
+        <version.eap74-rhel8-byos-vmss>1.0.23</version.eap74-rhel8-byos-vmss>
+        <version.eap74-rhel8-payg>1.0.27</version.eap74-rhel8-payg>
+        <version.eap74-rhel8-payg-multivm>1.0.28</version.eap74-rhel8-payg-multivm>
+        <version.eap74-rhel8-payg-vmss>1.0.27</version.eap74-rhel8-payg-vmss>
         <version.eap-aro>1.0.17</version.eap-aro>
     </properties>
 

--- a/utilities/azure-common.properties
+++ b/utilities/azure-common.properties
@@ -60,5 +60,4 @@ azure.apiVersionForStorageBlobService=2023-01-01
 # Microsoft.RedHatOpenShift/openShiftClusters
 azure.apiVersionForOpenShiftClusters=2023-04-01
 
-
-
+azure.armBased.vmSize.list="Standard_D2plds_v5","Standard_D4plds_v5","Standard_D8plds_v5","Standard_D16plds_v5","Standard_D32plds_v5","Standard_D48plds_v5","Standard_D64plds_v5","Standard_D2pls_v5","Standard_D4pls_v5","Standard_D8pls_v5","Standard_D16pls_v5","Standard_D32pls_v5","Standard_D48pls_v5","Standard_D64pls_v5","Standard_D2pds_v5","Standard_D4pds_v5","Standard_D8pds_v5","Standard_D16pds_v5","Standard_D32pds_v5","Standard_D48pds_v5","Standard_D64pds_v5","Standard_D2ps_v5","Standard_D4ps_v5","Standard_D8ps_v5","Standard_D16ps_v5","Standard_D32ps_v5","Standard_D48ps_v5","Standard_D64ps_v5","Standard_E2pds_v5","Standard_E4pds_v5","Standard_E8pds_v5","Standard_E16pds_v5","Standard_E20pds_v5","Standard_E32pds_v5","Standard_E2ps_v5","Standard_E4ps_v5","Standard_E8ps_v5","Standard_E16ps_v5","Standard_E20ps_v5","Standard_E32ps_v5","Standard_B2pls_v2","Standard_B2ps_v2","Standard_B2pts_v2","Standard_B4pls_v2","Standard_B4ps_v2","Standard_B8pls_v2","Standard_B8ps_v2","Standard_B16pls_v2","Standard_B16ps_v2"


### PR DESCRIPTION
## Context
In our offers, we used 4 images:
- `rhel-lvm86-gen2` for byos offers
- `rh-jboss-eap74-jdk8-rhel8`
- `rh-jboss-eap74-jdk11-rhel8`
- `rh-jboss-eap74-jdk17-rhel8`

All of them only support  `x64` based CPU architecture:
`az vm image list --publisher RedHat --offer rh-jboss-eap --all --output table|grep rh-jboss-eap74`
![image](https://github.com/user-attachments/assets/98e304b0-eaa3-4b9e-852f-6774ed1d3daa)

It will fail if users choose arm6 based vm size.


## Goal
Exclude all arm64 cpu based vm sizes in the `createUiDefinition.json`, so users can only choose supported vm size.

## Test
### Test provision with arm64 vm size
- Expected: Failed
- Result: Failed
- Test: Passed
  - ![image](https://github.com/user-attachments/assets/7e64462c-0425-436f-b38f-959d18d068ca)

### Test choose with unsupported VM size
- Expected: Show Error
- Result: Show Error
- Test: Passed
 - ![image](https://github.com/user-attachments/assets/50070d43-4fc4-4e45-bb0b-adefa0f6dcce)

### Test only show supported vm size
- Expected: No vm size option contains lower letter `p`
- Result: No vm size option contains lower letter `p`
- Test: Passed
 - ![image](https://github.com/user-attachments/assets/cedc8ca1-6adc-4501-85e1-b05c7c1369f1)


### Test workflow
- [Validate payg offer](https://github.com/azure-javaee/rhel-jboss-templates/actions/runs/10071987759) ✅
  -  ![image](https://github.com/user-attachments/assets/951ac745-a8fe-4fff-b8f1-2afa92ba4f51)
- [Validate byos offer #42](https://github.com/azure-javaee/rhel-jboss-templates/actions/runs/10071984823) ✅
  - ![image](https://github.com/user-attachments/assets/798e9f12-a3be-4418-80b5-e5ba7149bafd)


