### PR TITLE
Update Maven War Plugin version to 3.4.0 

### DIFF
--- a/eap-coffee-app/pom.xml
+++ b/eap-coffee-app/pom.xml
@@ -44,6 +44,11 @@
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.2.0</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.4.0</version>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/eap-session-replication/pom.xml
+++ b/eap-session-replication/pom.xml
@@ -29,6 +29,13 @@
 
     <build>
         <finalName>session-replication</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.4.0</version>
+            </plugin>
+        </plugins>
     </build>
     
 </project>


### PR DESCRIPTION
## Context
Refer to [r-837](https://dev.azure.com/azure-redhat-projects/azure-redhat-projects/_workitems/edit/837)
If run `mvn clean package` in the root directory with JDK 17, it will throw exception.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-war-plugin:2.2:war (default-war) on project javaee-cafe:  
 Execution default-war of goal org.apache.maven.plugins:maven-war-plugin:2.2:war failed: Unable to load the mojo 'war'  
 in the plugin 'org.apache.maven.plugins:maven-war-plugin:2.2' due to an API incompatibility:  
 org.codehaus.plexus.component.repository.exception.ComponentLookupException:   
Cannot access defaults field of Properties
```
![image](https://github.com/user-attachments/assets/6aa4e551-783a-4311-bd01-988e2c3a9ca7)

## Goal

This PR is used to fix this issue, so that the repo can build with JDK8,JDK11,JDK18 and above.


## Tests ✅
JDK8 ✅
![image](https://github.com/user-attachments/assets/7426c41a-16ee-4c8b-b13a-396ae9123565)
JDK11 ✅

![image](https://github.com/user-attachments/assets/08d448f3-a2db-4527-9549-909cf26dc397)

JDK17 ✅
![image](https://github.com/user-attachments/assets/5bb3b851-1a44-40ed-8fed-43a3f165ab77)

