### PR TITLE
Update artifact upload/download version to v4 in GitHub Actions workflow

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -123,7 +123,7 @@ runs:
         fi
 
     - name: Archive ${{ inputs.offerName }} template
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: success()
       with:
         name: ${{steps.artifact_file.outputs.artifactName}}

--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -189,7 +189,7 @@ jobs:
               with:
                 path: rhel-jboss-templates
             - name: Download artifact for deployment
-              uses: actions/download-artifact@v1
+              uses: actions/download-artifact@v4
               with:
                 name: ${{needs.preflight.outputs.artifactName}}
                 path: rhel-jboss-templates-dev
@@ -415,7 +415,7 @@ jobs:
               with:
                 path: rhel-jboss-templates
             - name: Download artifact for test branch
-              uses: actions/download-artifact@v1
+              uses: actions/download-artifact@v4
               with:
                 name: ${{needs.preflight.outputs.artifactName}}
                 path: rhel-jboss-templates-dev

--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -282,7 +282,7 @@ jobs:
                 ${dbPassword}"
 
             - name: Archive parameters-test-domain.json
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v4
               if: success()
               with:
                 name: parameters-test-domain
@@ -506,7 +506,7 @@ jobs:
                 ${dbPassword}"
 
             - name: Archive parameters-test-standalone.json
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v4
               if: success()
               with:
                 name: parameters-test-standalone

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -243,7 +243,7 @@ jobs:
                 ${dbPassword}"
 
             - name: Archive parameters-test-single.json
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v4
               if: success()
               with:
                 name: parameters-test-single

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -74,7 +74,7 @@ jobs:
               with:
                 path: rhel-jboss-templates
             - name: Download artifact for test branch
-              uses: actions/download-artifact@v1
+              uses: actions/download-artifact@v4
               with:
                 name: ${{needs.preflight.outputs.artifactName}}
                 path: rhel-jboss-templates-dev

--- a/.github/workflows/validate-byos-vmss.yaml
+++ b/.github/workflows/validate-byos-vmss.yaml
@@ -78,7 +78,7 @@ jobs:
               with:
                 path: rhel-jboss-templates
             - name: Download artifact for test branch
-              uses: actions/download-artifact@v1
+              uses: actions/download-artifact@v4
               with:
                 name: ${{needs.preflight.outputs.artifactName}}
                 path: rhel-jboss-templates-dev

--- a/.github/workflows/validate-byos-vmss.yaml
+++ b/.github/workflows/validate-byos-vmss.yaml
@@ -248,7 +248,7 @@ jobs:
                 ${dbPassword}"
 
             - name: Archive parameters-test-vmss.json
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v4
               if: success()
               with:
                 name: parameters-test-vmss

--- a/.github/workflows/validate-eap-aro.yaml
+++ b/.github/workflows/validate-eap-aro.yaml
@@ -108,7 +108,7 @@ jobs:
           echo $params |bash rhel-jboss-templates/eap-aro/src/test/scripts/gen-parameters.sh 
 
       - name: Archive parameters-test-eap-aro.json
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         if: success()
         with:
           name: parameters-test-eap-aro

--- a/.github/workflows/validate-eap-aro.yaml
+++ b/.github/workflows/validate-eap-aro.yaml
@@ -56,7 +56,7 @@ jobs:
         with:
           path: rhel-jboss-templates
       - name: Download artifact for test branch
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: ${{needs.preflight.outputs.artifactName}}
           path: rhel-jboss-templates-dev

--- a/.github/workflows/validate-payg-multivm.yaml
+++ b/.github/workflows/validate-payg-multivm.yaml
@@ -280,7 +280,7 @@ jobs:
                 ${{ inputs.jdkVersion }} "
 
             - name: Archive parameters-test-domain.json
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v4
               if: success()
               with:
                 name: parameters-test-domain
@@ -499,7 +499,7 @@ jobs:
                 ${{ inputs.jdkVersion }} "
 
             - name: Archive parameters-test-standalone.json
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v4
               if: success()
               with:
                 name: parameters-test-standalone

--- a/.github/workflows/validate-payg-multivm.yaml
+++ b/.github/workflows/validate-payg-multivm.yaml
@@ -195,7 +195,7 @@ jobs:
               with:
                 path: rhel-jboss-templates
             - name: Download artifact for deployment
-              uses: actions/download-artifact@v1
+              uses: actions/download-artifact@v4
               with:
                 name: ${{needs.preflight.outputs.artifactName}}
                 path: rhel-jboss-templates-dev
@@ -413,7 +413,7 @@ jobs:
               with:
                 path: rhel-jboss-templates
             - name: Download artifact for test branch
-              uses: actions/download-artifact@v1
+              uses: actions/download-artifact@v4
               with:
                 name: ${{needs.preflight.outputs.artifactName}}
                 path: rhel-jboss-templates-dev

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -241,7 +241,7 @@ jobs:
                 ${{ inputs.jdkVersion }} "
 
             - name: Archive parameters-test-single.json
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v4
               if: success()
               with:
                 name: parameters-test-single

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -80,7 +80,7 @@ jobs:
               with:
                 path: rhel-jboss-templates
             - name: Download artifact for test branch
-              uses: actions/download-artifact@v1
+              uses: actions/download-artifact@v4
               with:
                 name: ${{needs.preflight.outputs.artifactName}}
                 path: rhel-jboss-templates-dev

--- a/.github/workflows/validate-payg-vmss.yaml
+++ b/.github/workflows/validate-payg-vmss.yaml
@@ -246,7 +246,7 @@ jobs:
                 ${{ inputs.jdkVersion }} "
 
             - name: Archive parameters-test-vmss.json
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v4
               if: success()
               with:
                 name: parameters-test-vmss

--- a/.github/workflows/validate-payg-vmss.yaml
+++ b/.github/workflows/validate-payg-vmss.yaml
@@ -84,7 +84,7 @@ jobs:
               with:
                 path: rhel-jboss-templates
             - name: Download artifact for test branch
-              uses: actions/download-artifact@v1
+              uses: actions/download-artifact@v4
               with:
                 name: ${{needs.preflight.outputs.artifactName}}
                 path: rhel-jboss-templates-dev


### PR DESCRIPTION
## Context
`actions/upload-artifact@v1` is deprecated. > check [Deprecation notice: v1 and v2 of the artifact actions](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)
`actions/download-artifact@v1` is deprecated. > check [Deprecation notice: v1 and v2 of the artifact actions](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)

> No need to update offer versions.

## Goal
`upgrade actions/upload-artifact@v1` to actions/upload-artifact@v4
`upgrade actions/download-artifact@v1` to actions/download-artifact@v4