### PR TITLE
Add JDK version input to workflows for enhanced validation flexibility

### DIFF
--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -1,4 +1,5 @@
 name: Validate byos-multivm offer
+run-name: Validate byos-multivm offer with ${{ inputs.jdkVersion }} and ${{ inputs.databaseType }}
 
 on:
   workflow_dispatch:
@@ -14,6 +15,15 @@ on:
         - mysql
         - postgresql
         - none
+      jdkVersion:
+        description: 'jdkVersion'
+        required: true
+        default: 'openjdk17'
+        type: choice
+        options:
+          - openjdk8
+          - openjdk11
+          - openjdk17
       timeWaitBeforeDelete:
         description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 6h (6 hours), 0 (immediately)'
         required: true
@@ -279,7 +289,8 @@ jobs:
                 java:jboss/datasources/JavaEECafeDB \
                 ${dsConnectionURL} \
                 ${dbUser} \
-                ${dbPassword}"
+                ${dbPassword} \
+                ${{ inputs.jdkVersion }} "
 
             - name: Archive parameters-test-domain.json
               uses: actions/upload-artifact@v4
@@ -503,7 +514,8 @@ jobs:
                 java:jboss/datasources/JavaEECafeDB \
                 ${dsConnectionURL} \
                 ${dbUser} \
-                ${dbPassword}"
+                ${dbPassword} \
+                ${{ inputs.jdkVersion }} "
 
             - name: Archive parameters-test-standalone.json
               uses: actions/upload-artifact@v4

--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -1,5 +1,5 @@
 name: Validate byos-multivm offer
-run-name: Validate byos-multivm offer with ${{ inputs.jdkVersion }} and ${{ inputs.databaseType }}
+run-name: Validate byos-multivm offer with db:${{ inputs.jdkVersion }} and jdk:${{ inputs.databaseType }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -1,5 +1,5 @@
 name: Validate byos offer
-run-name: Validate byos offer with ${{ inputs.jdkVersion }} and ${{ inputs.databaseType }}
+run-name: Validate byos offer with db:${{ inputs.jdkVersion }} and jdk:${{ inputs.databaseType }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -18,12 +18,14 @@ on:
       jdkVersion:
         description: 'jdkVersion'
         required: true
-        default: 'openjdk17'
+        default: 'eap8-openjdk17'
         type: choice
         options:
-          - openjdk8
-          - openjdk11
-          - openjdk17
+          - eap8-openjdk17
+          - eap8-openjdk11
+          - eap74-openjdk17
+          - eap74-openjdk11
+          - eap74-openjdk8
       timeWaitBeforeDelete:
         description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 6h (6 hours), 0 (immediately)'
         required: true

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -1,4 +1,5 @@
 name: Validate byos offer
+run-name: Validate byos offer with ${{ inputs.jdkVersion }} and ${{ inputs.databaseType }}
 
 on:
   workflow_dispatch:
@@ -14,6 +15,15 @@ on:
         - mysql
         - postgresql
         - none
+      jdkVersion:
+        description: 'jdkVersion'
+        required: true
+        default: 'openjdk17'
+        type: choice
+        options:
+          - openjdk8
+          - openjdk11
+          - openjdk17
       timeWaitBeforeDelete:
         description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 6h (6 hours), 0 (immediately)'
         required: true
@@ -240,7 +250,8 @@ jobs:
                 java:jboss/datasources/JavaEECafeDB \
                 ${dsConnectionURL} \
                 ${dbUser} \
-                ${dbPassword}"
+                ${dbPassword} \
+                ${{ inputs.jdkVersion }} "
 
             - name: Archive parameters-test-single.json
               uses: actions/upload-artifact@v4

--- a/.github/workflows/validate-byos-vmss.yaml
+++ b/.github/workflows/validate-byos-vmss.yaml
@@ -1,4 +1,5 @@
 name: Validate byos-vmss offer
+run-name: Validate byos-vmss offer with ${{ inputs.jdkVersion }} and ${{ inputs.databaseType }}
 
 on:
   workflow_dispatch:
@@ -14,6 +15,15 @@ on:
         - mysql
         - postgresql
         - none
+      jdkVersion:
+        description: 'jdkVersion'
+        required: true
+        default: 'openjdk17'
+        type: choice
+        options:
+          - openjdk8
+          - openjdk11
+          - openjdk17
       timeWaitBeforeDelete:
         description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 6h (6 hours), 0 (immediately)'
         required: true
@@ -245,7 +255,8 @@ jobs:
                 java:jboss/datasources/JavaEECafeDB \
                 ${dsConnectionURL} \
                 ${dbUser} \
-                ${dbPassword}"
+                ${dbPassword} \
+                ${{ inputs.jdkVersion }} "
 
             - name: Archive parameters-test-vmss.json
               uses: actions/upload-artifact@v4

--- a/.github/workflows/validate-byos-vmss.yaml
+++ b/.github/workflows/validate-byos-vmss.yaml
@@ -1,5 +1,5 @@
 name: Validate byos-vmss offer
-run-name: Validate byos-vmss offer with ${{ inputs.jdkVersion }} and ${{ inputs.databaseType }}
+run-name: Validate byos-vmss offer with db:${{ inputs.jdkVersion }} and jdk:${{ inputs.databaseType }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/validate-payg-multivm.yaml
+++ b/.github/workflows/validate-payg-multivm.yaml
@@ -1,5 +1,5 @@
 name: Validate payg-multivm offer
-run-name: Validate payg-multivm offer with ${{ inputs.jdkVersion }} and ${{ inputs.databaseType }}
+run-name: Validate payg-multivm offer with db:${{ inputs.jdkVersion }} and jdk:${{ inputs.databaseType }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/validate-payg-multivm.yaml
+++ b/.github/workflows/validate-payg-multivm.yaml
@@ -1,4 +1,5 @@
 name: Validate payg-multivm offer
+run-name: Validate payg-multivm offer with ${{ inputs.jdkVersion }} and ${{ inputs.databaseType }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -1,5 +1,5 @@
 name: Validate payg offer
-run-name: Validate payg offer with ${{ inputs.jdkVersion }} and ${{ inputs.databaseType }}
+run-name: Validate payg offer with db:${{ inputs.jdkVersion }} and jdk:${{ inputs.databaseType }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -1,4 +1,5 @@
 name: Validate payg offer
+run-name: Validate payg offer with ${{ inputs.jdkVersion }} and ${{ inputs.databaseType }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/validate-payg-vmss.yaml
+++ b/.github/workflows/validate-payg-vmss.yaml
@@ -1,4 +1,5 @@
 name: Validate payg-vmss offer
+run-name: Validate payg-vmss offer with ${{ inputs.jdkVersion }} and ${{ inputs.databaseType }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/validate-payg-vmss.yaml
+++ b/.github/workflows/validate-payg-vmss.yaml
@@ -1,5 +1,5 @@
 name: Validate payg-vmss offer
-run-name: Validate payg-vmss offer with ${{ inputs.jdkVersion }} and ${{ inputs.databaseType }}
+run-name: Validate payg-vmss offer with db:${{ inputs.jdkVersion }} and jdk:${{ inputs.databaseType }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
> [!NOTE]  
> This PR should be merged after https://github.com/Azure/rhel-jboss-templates/pull/257.


Refer to [902](https://dev.azure.com/azure-redhat-projects/azure-redhat-projects/_workitems/edit/902)

## Summary
This pull request includes updates to several GitHub Actions workflows to support specifying the JDK version as an input parameter. The changes primarily add a new input for `jdkVersion` and modify the run names and job commands to incorporate this input.

> [!NOTE]  
> The PR https://github.com/Azure/rhel-jboss-templates/pull/254 has changed the jdkVersion value for single payg offer.


## Updates to GitHub Actions workflows:

### jdkVersion

**Before** >>  <img width="323" alt="image" src="https://github.com/user-attachments/assets/a6277da8-1574-474f-9fa8-bd4f806aefd0">

**After** >>  <img width="323" alt="image" src="https://github.com/user-attachments/assets/fb4ec690-45a2-4821-a2a8-7e8f20d5ffbc">

----

### run-name

**Before** >>  <img width="663" alt="image" src="https://github.com/user-attachments/assets/13253cb3-8b2b-465e-bd0c-33e26df9c881">

**After** >>  <img width="663" alt="image" src="https://github.com/user-attachments/assets/25710110-27b6-4b67-b38b-1563c9c28572">

----

### eap74-rhel8-byos jdkVersion options
<img width="295" alt="image" src="https://github.com/user-attachments/assets/e7e88ce6-c766-47c9-badb-90a627e08bbc">
