### PR TITLE
[Fix] pipeline-"Validate byos offer" failure

### DIFF
--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -103,6 +103,7 @@ jobs:
               run: |
                   echo "accept terms for VM image"
                   az vm image terms accept --urn redhat:rh-jboss-eap:rh-jboss-eap74-rhel8:latest
+                  az vm image terms accept --urn redhat:rhel-byos:rhel-lvm94-gen2:latest
             - name: Deploy an instance of Azure SQL Database
               if: ${{ inputs.databaseType == 'mssqlserver' || github.event.client_payload.databaseType == 'mssqlserver' }}
               run: |

--- a/eap74-rhel8-byos/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-byos/src/main/scripts/jbosseap-setup-redhat.sh
@@ -103,7 +103,7 @@ sudo yum install curl wget unzip vim git -y | log; flag=${PIPESTATUS[0]}
 
 ####################### 
 
-if [[ "${JDK_VERSION,,}" == "eap8-openjdk17" ] || [ "${JDK_VERSION,,}" == "eap8-openjdk11" ]]; then
+if [[ "${JDK_VERSION,,}" == "eap8-openjdk17" || "${JDK_VERSION,,}" == "eap8-openjdk11" ]]; then
 # Install JBoss EAP 8
     echo "subscription-manager repos --enable=jb-eap-8.0-for-rhel-9-x86_64-rpms"         | log; flag=${PIPESTATUS[0]}
     subscription-manager repos --enable=jb-eap-8.0-for-rhel-9-x86_64-rpms                | log; flag=${PIPESTATUS[0]}
@@ -185,7 +185,7 @@ echo -e "JAVA_OPTS=\"\$JAVA_OPTS -Djboss.jgroups.azure_ping.container=$CONTAINER
 
 ####################### Start the JBoss server and setup eap service
 
-if [[ "${JDK_VERSION,,}" == "eap8-openjdk17" ] || [ "${JDK_VERSION,,}" == "eap8-openjdk11" ]]; then
+if [[ "${JDK_VERSION,,}" == "eap8-openjdk17" || "${JDK_VERSION,,}" == "eap8-openjdk11" ]]; then
     echo "Start JBoss-EAP service"                  | log; flag=${PIPESTATUS[0]}
     echo "systemctl enable eap8-standalone.service" | log; flag=${PIPESTATUS[0]}
     systemctl enable eap8-standalone.service        | log; flag=${PIPESTATUS[0]}

--- a/eap74-rhel8-byos/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-byos/src/main/scripts/jbosseap-setup-redhat.sh
@@ -35,7 +35,7 @@ databaseUser=${16}
 databasePassword=${17}
 NODE_ID=$(uuidgen | sed 's/-//g' | cut -c 1-23)
 
-if [[ "${JDK_VERSION,,}" == "eap8-openjdk17" ] || [ "${JDK_VERSION,,}" == "eap8-openjdk11" ]]; then
+if [[ "${JDK_VERSION,,}" == "eap8-openjdk17" || "${JDK_VERSION,,}" == "eap8-openjdk11" ]]; then
 
     export EAP_HOME="/opt/rh/eap8/root/usr/share/wildfly"
     export EAP_RPM_CONF_STANDALONE="/etc/opt/rh/eap8/wildfly/eap8-standalone.conf"

--- a/eap74-rhel8-byos/src/main/scripts/jbosseap-setup-redhat.sh
+++ b/eap74-rhel8-byos/src/main/scripts/jbosseap-setup-redhat.sh
@@ -155,7 +155,7 @@ echo -e "\t stack UDP to TCP"       | log; flag=${PIPESTATUS[0]}
 echo -e "\t set transaction id"     | log; flag=${PIPESTATUS[0]}
 
 ## OpenJDK 17 specific logic
-if [[ "${JDK_VERSION,,}" == "eap7-openjdk17" ] || [ "${JDK_VERSION,,}" == "eap8-openjdk17" ]]; then
+if [[ "${JDK_VERSION,,}" == "eap7-openjdk17" || "${JDK_VERSION,,}" == "eap8-openjdk17" ]]; then
     sudo -u jboss $EAP_HOME/bin/jboss-cli.sh --file=$EAP_HOME/docs/examples/enable-elytron-se17.cli -Dconfig=standalone-full-ha.xml
 fi
 


### PR DESCRIPTION
## Background
Pipeline [Run-11043910161](https://github.com/azure-javaee/rhel-jboss-templates/actions/runs/11043910161) failed

---

Task [901](https://dev.azure.com/azure-redhat-projects/azure-redhat-projects/_workitems/edit/901)


## Summary

This pull request includes several updates to the `eap74-rhel8-byos` setup scripts and the `.github/workflows/validate-byos-singlenode.yaml` workflow file. The changes primarily focus on correcting logical conditions and expanding VM image acceptance in the workflow.

### Workflow Updates:
* Added acceptance of a new VM image in the GitHub Actions workflow (`.github/workflows/validate-byos-singlenode.yaml`).

### Script Corrections:
* Fixed logical conditions in multiple instances to properly use the `||` operator instead of a mix of `||` and `]` (`eap74-rhel8-byos/src/main/scripts/jbosseap-setup-redhat.sh`). [[1]](diffhunk://#diff-a08c219eb06b658a17d7467aec0104fa403b79d3ef33f584f6cb4ede9dfc6dfeL38-R38) [[2]](diffhunk://#diff-a08c219eb06b658a17d7467aec0104fa403b79d3ef33f584f6cb4ede9dfc6dfeL106-R106) [[3]](diffhunk://#diff-a08c219eb06b658a17d7467aec0104fa403b79d3ef33f584f6cb4ede9dfc6dfeL158-R158) [[4]](diffhunk://#diff-a08c219eb06b658a17d7467aec0104fa403b79d3ef33f584f6cb4ede9dfc6dfeL188-R188)


## Test
[Run-11046472950](https://github.com/azure-javaee/rhel-jboss-templates/actions/runs/11046472950)
<img width="1250" alt="image" src="https://github.com/user-attachments/assets/c0df73b8-c50c-4e71-a152-f27872e02561">
