### PR TITLE
Update wait time option from 6h to 5h in all workflow files.

### DIFF
--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -27,14 +27,14 @@ on:
           - eap74-openjdk11
           - eap74-openjdk8
       timeWaitBeforeDelete:
-        description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 6h (6 hours), 0 (immediately)'
+        description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 5h (5 hours), 0 (immediately)'
         required: true
         type: choice
         default: 0
         options:
           - 30m
           - 2h
-          - 6h
+          - 5h
           - 0
 
 env:

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -27,14 +27,14 @@ on:
           - eap74-openjdk11
           - eap74-openjdk8
       timeWaitBeforeDelete:
-        description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 6h (6 hours), 0 (immediately)'
+        description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 5h (5 hours), 0 (immediately)'
         required: true
         type: choice
         default: 0
         options:
           - 30m
           - 2h
-          - 6h
+          - 5h
           - 0
 
 env:

--- a/.github/workflows/validate-byos-vmss.yaml
+++ b/.github/workflows/validate-byos-vmss.yaml
@@ -27,14 +27,14 @@ on:
           - eap74-openjdk11
           - eap74-openjdk8
       timeWaitBeforeDelete:
-        description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 6h (6 hours), 0 (immediately)'
+        description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 5h (5 hours), 0 (immediately)'
         required: true
         type: choice
         default: 0
         options:
           - 30m
           - 2h
-          - 6h
+          - 5h
           - 0
 
 env:

--- a/.github/workflows/validate-eap-aro.yaml
+++ b/.github/workflows/validate-eap-aro.yaml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       timeWaitBeforeDelete:
-        description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 6h (6 hours), 0 (immediately)'
+        description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 5h (5 hours), 0 (immediately)'
         required: true
         type: choice
         default: 0
         options:
           - 30m
           - 2h
-          - 6h
+          - 5h
           - 0
 
 env:

--- a/.github/workflows/validate-payg-multivm.yaml
+++ b/.github/workflows/validate-payg-multivm.yaml
@@ -25,14 +25,14 @@ on:
           - openjdk11
           - openjdk17
       timeWaitBeforeDelete:
-        description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 6h (6 hours), 0 (immediately)'
+        description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 5h (5 hours), 0 (immediately)'
         required: true
         type: choice
         default: 0
         options:
           - 30m
           - 2h
-          - 6h
+          - 5h
           - 0
 
 env:

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -25,14 +25,14 @@ on:
           - openjdk11
           - openjdk17
       timeWaitBeforeDelete:
-        description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 6h (6 hours), 0 (immediately)'
+        description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 5h (5 hours), 0 (immediately)'
         required: true
         type: choice
         default: 0
         options:
           - 30m
           - 2h
-          - 6h
+          - 5h
           - 0
 
 env:

--- a/.github/workflows/validate-payg-vmss.yaml
+++ b/.github/workflows/validate-payg-vmss.yaml
@@ -25,14 +25,14 @@ on:
           - openjdk11
           - openjdk17
       timeWaitBeforeDelete:
-        description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 6h (6 hours), 0 (immediately)'
+        description: 'Choose the wait time before deleting resources: 30m (30 minutes), 2h (2 hours), 5h (5 hours), 0 (immediately)'
         required: true
         type: choice
         default: 0
         options:
           - 30m
           - 2h
-          - 6h
+          - 5h
           - 0
 
 env:


### PR DESCRIPTION
## Background
There are 6 hours usage limits for each job.
<img width="781" alt="image" src="https://github.com/user-attachments/assets/eecd1c13-b426-4c05-bec8-b7c7a83c48f5">

https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#usage-limits


## Goal
Update wait time option from 6h to 5h in all workflow files.