### PR TITLE
Fix deployment issues: update version of OLO to 1.4.1 and install missing library for oc cmdlet

### DIFF
--- a/eap-aro/src/main/scripts/jboss-setup.sh
+++ b/eap-aro/src/main/scripts/jboss-setup.sh
@@ -373,6 +373,15 @@ apk update
 apk add gettext
 apk add apache2-utils
 
+# Check if /usr/lib/libresolv.so.2 exists that is required by the OpenShift CLI
+if [ ! -f /usr/lib/libresolv.so.2 ]; then
+    echo "Install gcompat package which provides /usr/lib/libresolv.so.2"
+    apk add gcompat
+
+    echo "Create a symbolic link for /usr/lib/libresolv.so.2"
+    ln -sf /lib/libgcompat.so.0 /usr/lib/libresolv.so.2
+fi
+
 # Retrieve cluster credentials and api/console URLs
 credentials=$(az aro list-credentials -g $RESOURCE_GROUP -n $CLUSTER_NAME -o json)
 kubeadminUsername=$(echo $credentials | jq -r '.kubeadminUsername')

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.eap-rhel-payg>1.0.34</version.eap-rhel-payg>
         <version.eap74-rhel8-payg-multivm>1.0.33</version.eap74-rhel8-payg-multivm>
         <version.eap74-rhel8-payg-vmss>1.0.34</version.eap74-rhel8-payg-vmss>
-        <version.eap-aro>1.0.20</version.eap-aro>
+        <version.eap-aro>1.0.21</version.eap-aro>
     </properties>
 
     <modules>


### PR DESCRIPTION
Refer to @majguo 's PR https://github.com/WASdev/azure.liberty.aro/pull/130
jboss-eap-aro has the same issue.
