### PR TITLE
Jboss EAP workflows support postgresql flexible server

### DIFF
--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -191,8 +191,12 @@ jobs:
                 host=$(az postgres flexible-server show \
                   --resource-group ${{ env.dependencyResourceGroup}} --name ${{ env.dbInstanceName }} \
                   --query "fullyQualifiedDomainName" -o tsv)
-                az postgres flexible-server db create --resource-group ${{ env.dependencyResourceGroup}} --server-name ${{ env.dbInstanceName }} --database-name testdb
+                az postgres flexible-server db create --resource-group ${{ env.dependencyResourceGroup}} \
+                                                      --server-name ${{ env.dbInstanceName }} \
+                                                      --database-name testdb
+                
                 echo "postgresqlHost=${host}" >> "$GITHUB_OUTPUT"
+
     deploy-multivm-domain:
         needs: 
           - preflight

--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -276,7 +276,7 @@ jobs:
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ needs.deploy-dependent-resources.outputs.postgresqlHost }}:5432/testdb"
-                  dbUser=testuser@${{ env.dbInstanceName }}
+                  dbUser=testuser
                   dbPassword=${{ env.dbPassword }}
                 fi
                 echo "enableDB=${enableDB}" >> "$GITHUB_ENV"

--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -13,7 +13,7 @@ on:
         - mssqlserver
         - oracle
         - mysql(flexible)
-        - postgresql(single)
+        - postgresql(flexible)
         - none
       jdkVersion:
         description: 'jdkVersion'
@@ -180,7 +180,7 @@ jobs:
                 EOF
             - name: Deploy an instance of Azure Database for PostgreSQL
               id: deploy-postgresql
-              if: ${{ inputs.databaseType == 'postgresql(single)' || github.event.client_payload.databaseType == 'postgresql(single)' }}
+              if: ${{ inputs.databaseType == 'postgresql(flexible)' || github.event.client_payload.databaseType == 'postgresql(flexible)' }}
               run: |
                 az postgres flexible-server create \
                   --resource-group ${{ env.dependencyResourceGroup}} --name ${{ env.dbInstanceName }} \
@@ -268,7 +268,7 @@ jobs:
                   fi
                   dbUser=testuser
                   dbPassword=${{ env.dbPassword }}
-                elif ${{ inputs.databaseType == 'postgresql(single)' || github.event.client_payload.databaseType == 'postgresql(single)' }}; then
+                elif ${{ inputs.databaseType == 'postgresql(flexible)' || github.event.client_payload.databaseType == 'postgresql(flexible)' }}; then
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ needs.deploy-dependent-resources.outputs.postgresqlHost }}:5432/testdb"
@@ -523,7 +523,7 @@ jobs:
                   fi
                   dbUser=testuser
                   dbPassword=${{ env.dbPassword }}
-                elif ${{ inputs.databaseType == 'postgresql(single)' || github.event.client_payload.databaseType == 'postgresql(single)' }}; then
+                elif ${{ inputs.databaseType == 'postgresql(flexible)' || github.event.client_payload.databaseType == 'postgresql(flexible)' }}; then
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ needs.deploy-dependent-resources.outputs.postgresqlHost }}:5432/testdb"

--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -182,20 +182,17 @@ jobs:
               id: deploy-postgresql
               if: ${{ inputs.databaseType == 'postgresql(single)' || github.event.client_payload.databaseType == 'postgresql(single)' }}
               run: |
-                az postgres server create \
+                az postgres flexible-server create \
                   --resource-group ${{ env.dependencyResourceGroup}} --name ${{ env.dbInstanceName }} \
                   --admin-user testuser --admin-password ${{ env.dbPassword }} \
-                  --location ${{ env.location }}
-                host=$(az postgres server show \
+                  --public-access 0.0.0.0 \
+                  --location ${{ env.location }} \
+                  --yes
+                host=$(az postgres flexible-server show \
                   --resource-group ${{ env.dependencyResourceGroup}} --name ${{ env.dbInstanceName }} \
                   --query "fullyQualifiedDomainName" -o tsv)
-                # Allow Azure services to access
-                az postgres server firewall-rule create \
-                  --resource-group ${{ env.dependencyResourceGroup}} --server ${{ env.dbInstanceName }} \
-                  --name "AllowAllAzureIps" --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
-                az postgres db create --resource-group ${{ env.dependencyResourceGroup}} --server ${{ env.dbInstanceName }} --name testdb
+                az postgres flexible-server db create --resource-group ${{ env.dependencyResourceGroup}} --server-name ${{ env.dbInstanceName }} --database-name testdb
                 echo "postgresqlHost=${host}" >> "$GITHUB_OUTPUT"
-
     deploy-multivm-domain:
         needs: 
           - preflight

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -194,18 +194,21 @@ jobs:
               if: ${{ inputs.databaseType == 'postgresql(flexible)' || github.event.client_payload.databaseType == 'postgresql(flexible)' }}
               run: |
                 az group create -n ${{ env.singleResourceGroup }} -l ${{ env.location }}
+                echo "create postgresql server"
                 az postgres flexible-server create \
-                  --resource-group ${{ env.singleResourceGroup }} 
+                  --resource-group ${{ env.singleResourceGroup }} \ 
                   --name ${{ env.dbInstanceName }} \
                   --admin-user testuser 
                   --admin-password ${{ env.dbPassword }} \
                   --public-access 0.0.0.0 \
                   --location ${{ env.location }} \
                   --yes
+                echo "get host name"
                 host=$(az postgres flexible-server show \
                   --resource-group ${{ env.singleResourceGroup }} --name ${{ env.dbInstanceName }} \
                   --query "fullyQualifiedDomainName" -o tsv)
                 echo "postgresqlHost=${host}" >> "$GITHUB_ENV"
+                echo "create firewall rule"
                 az postgres flexible-server db create --resource-group ${{ env.singleResourceGroup }} \
                                                       --server-name ${{ env.dbInstanceName }} \
                                                       --database-name testdb \

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -194,7 +194,6 @@ jobs:
               if: ${{ inputs.databaseType == 'postgresql(flexible)' || github.event.client_payload.databaseType == 'postgresql(flexible)' }}
               run: |
                 az group create -n ${{ env.singleResourceGroup }} -l ${{ env.location }}
-                echo "create postgresql server"
                 az postgres flexible-server create \
                   --resource-group ${{ env.singleResourceGroup }} \
                   --name ${{ env.dbInstanceName }} \
@@ -203,15 +202,15 @@ jobs:
                   --public-access 0.0.0.0 \
                   --location ${{ env.location }} \
                   --yes
-                echo "get host name"
                 host=$(az postgres flexible-server show \
                   --resource-group ${{ env.singleResourceGroup }} --name ${{ env.dbInstanceName }} \
                   --query "fullyQualifiedDomainName" -o tsv)
-                echo "postgresqlHost=${host}" >> "$GITHUB_ENV"
-                echo "create firewall rule"
                 az postgres flexible-server db create --resource-group ${{ env.singleResourceGroup }} \
                                                       --server-name ${{ env.dbInstanceName }} \
                                                       --database-name testdb
+                
+                echo "postgresqlHost=${host}" >> "$GITHUB_ENV"
+
             - name: Prepare parameter file
               run: |
                 enableDB=false

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -13,7 +13,7 @@ on:
         - mssqlserver
         - oracle
         - mysql(flexible)
-        - postgresql
+        - postgresql(flexible)
         - none
       jdkVersion:
         description: 'jdkVersion'
@@ -191,7 +191,7 @@ jobs:
                 FLUSH PRIVILEGES;
                 EOF
             - name: Deploy an instance of Azure Database for PostgreSQL
-              if: ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}
+              if: ${{ inputs.databaseType == 'postgresql(flexible)' || github.event.client_payload.databaseType == 'postgresql(flexible)' }}
               run: |
                 az group create -n ${{ env.singleResourceGroup }} -l ${{ env.location }}
                 az postgres flexible-server create \
@@ -239,7 +239,7 @@ jobs:
                   fi
                   dbUser=testuser
                   dbPassword=${{ env.dbPassword }}
-                elif ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
+                elif ${{ inputs.databaseType == 'postgresql(flexible)' || github.event.client_payload.databaseType == 'postgresql(flexible)' }}; then
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ env.postgresqlHost }}:5432/testdb"

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -211,8 +211,7 @@ jobs:
                 echo "create firewall rule"
                 az postgres flexible-server db create --resource-group ${{ env.singleResourceGroup }} \
                                                       --server-name ${{ env.dbInstanceName }} \
-                                                      --database-name testdb \
-                                                      --yes
+                                                      --database-name testdb
             - name: Prepare parameter file
               run: |
                 enableDB=false

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -13,7 +13,7 @@ on:
         - mssqlserver
         - oracle
         - mysql(flexible)
-        - postgresql(single)
+        - postgresql
         - none
       jdkVersion:
         description: 'jdkVersion'
@@ -191,7 +191,7 @@ jobs:
                 FLUSH PRIVILEGES;
                 EOF
             - name: Deploy an instance of Azure Database for PostgreSQL
-              if: ${{ inputs.databaseType == 'postgresql(single)' || github.event.client_payload.databaseType == 'postgresql(single)' }}
+              if: ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}
               run: |
                 az group create -n ${{ env.singleResourceGroup }} -l ${{ env.location }}
                 az postgres flexible-server create \
@@ -239,7 +239,7 @@ jobs:
                   fi
                   dbUser=testuser
                   dbPassword=${{ env.dbPassword }}
-                elif ${{ inputs.databaseType == 'postgresql(single)' || github.event.client_payload.databaseType == 'postgresql(single)' }}; then
+                elif ${{ inputs.databaseType == 'postgresql' || github.event.client_payload.databaseType == 'postgresql' }}; then
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ env.postgresqlHost }}:5432/testdb"

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -198,7 +198,7 @@ jobs:
                 az postgres flexible-server create \
                   --resource-group ${{ env.singleResourceGroup }} \ 
                   --name ${{ env.dbInstanceName }} \
-                  --admin-user testuser 
+                  --admin-user testuser \
                   --admin-password ${{ env.dbPassword }} \
                   --public-access 0.0.0.0 \
                   --location ${{ env.location }} \

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -196,7 +196,7 @@ jobs:
                 az group create -n ${{ env.singleResourceGroup }} -l ${{ env.location }}
                 echo "create postgresql server"
                 az postgres flexible-server create \
-                  --resource-group ${{ env.singleResourceGroup }} \ 
+                  --resource-group ${{ env.singleResourceGroup }} \
                   --name ${{ env.dbInstanceName }} \
                   --admin-user testuser \
                   --admin-password ${{ env.dbPassword }} \

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -208,7 +208,8 @@ jobs:
                 echo "postgresqlHost=${host}" >> "$GITHUB_ENV"
                 az postgres flexible-server db create --resource-group ${{ env.singleResourceGroup }} \
                                                       --server-name ${{ env.dbInstanceName }} \
-                                                      --database-name testdb
+                                                      --database-name testdb \
+                                                      --yes
             - name: Prepare parameter file
               run: |
                 enableDB=false

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -245,7 +245,7 @@ jobs:
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ env.postgresqlHost }}:5432/testdb"
-                  dbUser=testuser@${{ env.dbInstanceName }}
+                  dbUser=testuser
                   dbPassword=${{ env.dbPassword }}
                 fi
 

--- a/.github/workflows/validate-byos-singlenode.yaml
+++ b/.github/workflows/validate-byos-singlenode.yaml
@@ -194,19 +194,21 @@ jobs:
               if: ${{ inputs.databaseType == 'postgresql(single)' || github.event.client_payload.databaseType == 'postgresql(single)' }}
               run: |
                 az group create -n ${{ env.singleResourceGroup }} -l ${{ env.location }}
-                az postgres server create \
-                  --resource-group ${{ env.singleResourceGroup }} --name ${{ env.dbInstanceName }} \
-                  --admin-user testuser --admin-password ${{ env.dbPassword }} \
-                  --location ${{ env.location }}
-                host=$(az postgres server show \
+                az postgres flexible-server create \
+                  --resource-group ${{ env.singleResourceGroup }} 
+                  --name ${{ env.dbInstanceName }} \
+                  --admin-user testuser 
+                  --admin-password ${{ env.dbPassword }} \
+                  --public-access 0.0.0.0 \
+                  --location ${{ env.location }} \
+                  --yes
+                host=$(az postgres flexible-server show \
                   --resource-group ${{ env.singleResourceGroup }} --name ${{ env.dbInstanceName }} \
                   --query "fullyQualifiedDomainName" -o tsv)
                 echo "postgresqlHost=${host}" >> "$GITHUB_ENV"
-                # Allow Azure services to access
-                az postgres server firewall-rule create \
-                  --resource-group ${{ env.singleResourceGroup }} --server ${{ env.dbInstanceName }} \
-                  --name "AllowAllAzureIps" --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
-                az postgres db create --resource-group ${{ env.singleResourceGroup }} --server ${{ env.dbInstanceName }} --name testdb
+                az postgres flexible-server db create --resource-group ${{ env.singleResourceGroup }} \
+                                                      --server-name ${{ env.dbInstanceName }} \
+                                                      --database-name testdb
             - name: Prepare parameter file
               run: |
                 enableDB=false

--- a/.github/workflows/validate-payg-multivm.yaml
+++ b/.github/workflows/validate-payg-multivm.yaml
@@ -13,7 +13,7 @@ on:
         - mssqlserver
         - oracle
         - mysql(flexible)
-        - postgresql(single)
+        - postgresql(flexible)
         - none
       jdkVersion:
         description: 'jdkVersion'
@@ -177,20 +177,21 @@ jobs:
                 EOF
             - name: Deploy an instance of Azure Database for PostgreSQL
               id: deploy-postgresql
-              if: ${{ inputs.databaseType == 'postgresql(single)' || github.event.client_payload.databaseType == 'postgresql(single)' }}
+              if: ${{ inputs.databaseType == 'postgresql(flexible)' || github.event.client_payload.databaseType == 'postgresql(flexible)' }}
               run: |
-                az postgres server create \
+                az postgres flexible-server create \
                   --resource-group ${{ env.dependencyResourceGroup}} --name ${{ env.dbInstanceName }} \
                   --admin-user testuser --admin-password ${{ env.dbPassword }} \
-                  --location ${{ env.location }}
-                host=$(az postgres server show \
+                  --public-access 0.0.0.0 \
+                  --location ${{ env.location }} \
+                  --yes
+                host=$(az postgres flexible-server show \
                   --resource-group ${{ env.dependencyResourceGroup}} --name ${{ env.dbInstanceName }} \
                   --query "fullyQualifiedDomainName" -o tsv)
-                # Allow Azure services to access
-                az postgres server firewall-rule create \
-                  --resource-group ${{ env.dependencyResourceGroup}} --server ${{ env.dbInstanceName }} \
-                  --name "AllowAllAzureIps" --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
-                az postgres db create --resource-group ${{ env.dependencyResourceGroup}} --server ${{ env.dbInstanceName }} --name testdb
+                az postgres flexible-server db create --resource-group ${{ env.dependencyResourceGroup}} \
+                                                      --server-name ${{ env.dbInstanceName }} \
+                                                      --database-name testdb
+                
                 echo "postgresqlHost=${host}" >> "$GITHUB_OUTPUT"
 
     deploy-multivm-domain:
@@ -263,7 +264,7 @@ jobs:
                   fi
                   dbUser=testuser
                   dbPassword=${{ env.dbPassword }}
-                elif ${{ inputs.databaseType == 'postgresql(single)' || github.event.client_payload.databaseType == 'postgresql(single)' }}; then
+                elif ${{ inputs.databaseType == 'postgresql(flexible)' || github.event.client_payload.databaseType == 'postgresql(flexible)' }}; then
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ needs.deploy-dependent-resources.outputs.postgresqlHost }}:5432/testdb"
@@ -508,7 +509,7 @@ jobs:
                   fi
                   dbUser=testuser
                   dbPassword=${{ env.dbPassword }}
-                elif ${{ inputs.databaseType == 'postgresql(single)' || github.event.client_payload.databaseType == 'postgresql(single)' }}; then
+                elif ${{ inputs.databaseType == 'postgresql(flexible)' || github.event.client_payload.databaseType == 'postgresql(flexible)' }}; then
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ needs.deploy-dependent-resources.outputs.postgresqlHost }}:5432/testdb"

--- a/.github/workflows/validate-payg-multivm.yaml
+++ b/.github/workflows/validate-payg-multivm.yaml
@@ -513,7 +513,7 @@ jobs:
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ needs.deploy-dependent-resources.outputs.postgresqlHost }}:5432/testdb"
-                  dbUser=testuser@${{ env.dbInstanceName }}
+                  dbUser=testuser
                   dbPassword=${{ env.dbPassword }}
                 fi
 

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -13,7 +13,7 @@ on:
         - mssqlserver
         - oracle
         - mysql(flexible)
-        - postgresql(single)
+        - postgresql(flexible)
         - none
       jdkVersion:
         description: 'jdkVersion'
@@ -188,7 +188,7 @@ jobs:
                 FLUSH PRIVILEGES;
                 EOF
             - name: Deploy an instance of Azure Database for PostgreSQL
-              if: ${{ inputs.databaseType == 'postgresql(single)' || github.event.client_payload.databaseType == 'postgresql(single)' }}
+              if: ${{ inputs.databaseType == 'postgresql(flexible)' || github.event.client_payload.databaseType == 'postgresql(flexible)' }}
               run: |
                 az group create -n ${{ env.singleResourceGroup }} -l ${{ env.location }}
                 az postgres server create \
@@ -234,7 +234,7 @@ jobs:
                   fi
                   dbUser=testuser
                   dbPassword=${{ env.dbPassword }}
-                elif ${{ inputs.databaseType == 'postgresql(single)' || github.event.client_payload.databaseType == 'postgresql(single)' }}; then
+                elif ${{ inputs.databaseType == 'postgresql(flexible)' || github.event.client_payload.databaseType == 'postgresql(flexible)' }}; then
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ env.postgresqlHost }}:5432/testdb"

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -191,19 +191,23 @@ jobs:
               if: ${{ inputs.databaseType == 'postgresql(flexible)' || github.event.client_payload.databaseType == 'postgresql(flexible)' }}
               run: |
                 az group create -n ${{ env.singleResourceGroup }} -l ${{ env.location }}
-                az postgres server create \
-                  --resource-group ${{ env.singleResourceGroup }} --name ${{ env.dbInstanceName }} \
-                  --admin-user testuser --admin-password ${{ env.dbPassword }} \
-                  --location ${{ env.location }}
-                host=$(az postgres server show \
+                az postgres flexible-server create \
+                  --resource-group ${{ env.singleResourceGroup }} \
+                  --name ${{ env.dbInstanceName }} \
+                  --admin-user testuser \
+                  --admin-password ${{ env.dbPassword }} \
+                  --public-access 0.0.0.0 \
+                  --location ${{ env.location }} \
+                  --yes
+                host=$(az postgres flexible-server show \
                   --resource-group ${{ env.singleResourceGroup }} --name ${{ env.dbInstanceName }} \
                   --query "fullyQualifiedDomainName" -o tsv)
+                az postgres flexible-server db create --resource-group ${{ env.singleResourceGroup }} \
+                                                      --server ${{ env.dbInstanceName }} \
+                                                      --name testdb
+                
                 echo "postgresqlHost=${host}" >> "$GITHUB_ENV"
-                # Allow Azure services to access
-                az postgres server firewall-rule create \
-                  --resource-group ${{ env.singleResourceGroup }} --server ${{ env.dbInstanceName }} \
-                  --name "AllowAllAzureIps" --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
-                az postgres db create --resource-group ${{ env.singleResourceGroup }} --server ${{ env.dbInstanceName }} --name testdb
+
             - name: Prepare parameter file
               run: |
                 enableDB=false

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -203,8 +203,8 @@ jobs:
                   --resource-group ${{ env.singleResourceGroup }} --name ${{ env.dbInstanceName }} \
                   --query "fullyQualifiedDomainName" -o tsv)
                 az postgres flexible-server db create --resource-group ${{ env.singleResourceGroup }} \
-                                                      --server ${{ env.dbInstanceName }} \
-                                                      --name testdb
+                                                      --server-name ${{ env.dbInstanceName }} \
+                                                      --database-name testdb
                 
                 echo "postgresqlHost=${host}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/validate-payg-singlenode.yaml
+++ b/.github/workflows/validate-payg-singlenode.yaml
@@ -242,7 +242,7 @@ jobs:
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ env.postgresqlHost }}:5432/testdb"
-                  dbUser=testuser@${{ env.dbInstanceName }}
+                  dbUser=testuser
                   dbPassword=${{ env.dbPassword }}
                 fi
 


### PR DESCRIPTION
## Context
Refer to [1265](https://dev.azure.com/azure-redhat-projects/azure-redhat-projects/_workitems/edit/1265).
Currently, our workflows in [rhel-jboss-templates](https://github.com/azure-javaee/rhel-jboss-templates) support postgresql single server, but `Azure Database for PostgreSQL – Single Server retired by March 28 2025`, if we still using postgresql single server, we will get error 

- [The provided server type value 'Azure Database for PostgreSQL - Single Server' 
is invalid](https://github.com/azure-javaee/rhel-jboss-templates/actions/runs/15037209822/job/42261137421).


## Actions
Update workflows in [rhel-jboss-templates](https://github.com/azure-javaee/rhel-jboss-templates) to use postgersql flexible server.


## Testing work
