### PR TITLE
Remove dynamic dbUser assignment in PostgreSQL configurations

### DIFF
--- a/.github/workflows/validate-byos-multivm.yaml
+++ b/.github/workflows/validate-byos-multivm.yaml
@@ -520,7 +520,7 @@ jobs:
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ needs.deploy-dependent-resources.outputs.postgresqlHost }}:5432/testdb"
-                  dbUser=testuser@${{ env.dbInstanceName }}
+                  dbUser=testuser
                   dbPassword=${{ env.dbPassword }}
                 fi
 

--- a/.github/workflows/validate-payg-multivm.yaml
+++ b/.github/workflows/validate-payg-multivm.yaml
@@ -263,7 +263,7 @@ jobs:
                   enableDB=true
                   databaseType=postgresql
                   dsConnectionURL="jdbc:postgresql://${{ needs.deploy-dependent-resources.outputs.postgresqlHost }}:5432/testdb"
-                  dbUser=testuser@${{ env.dbInstanceName }}
+                  dbUser=testuser
                   dbPassword=${{ env.dbPassword }}
                 fi
                 echo "enableDB=${enableDB}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Changes
- As title
- The postgresql used in workflows has been changed from single server to flexible server in this [PR](https://github.com/Azure/rhel-jboss-templates/pull/298). The name pattern should also be changed, the [PR](https://github.com/Azure/rhel-jboss-templates/pull/298) has changed most of them but still missed two of them.


## Testing
- [payg-multivm offer](https://github.com/azure-javaee/rhel-jboss-templates/actions/runs/15244215871)
- [byos-multivm offer](https://github.com/azure-javaee/rhel-jboss-templates/actions/runs/15243610664)
