### PR TITLE
Correct ActiveDirectoryMsi to ActiveDirectoryMSI in connection string for SQL Server

### DIFF
--- a/eap-rhel-byos-multivm/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap-rhel-byos-multivm/src/main/scripts/create-ds-mssqlserver.sh
@@ -62,7 +62,7 @@ fi
 
 # Create data source
 if [ "$(echo "$enablePswlessConnection" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
-  dsConnectionString="$dsConnectionString;authentication=ActiveDirectoryMsi;msiClientId=${uamiClientId}"
+  dsConnectionString="$dsConnectionString;authentication=ActiveDirectoryMSI;msiClientId=${uamiClientId}"
   if [ $isManagedDomain == "false" ]; then
       echo "data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter" | log
       sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \

--- a/eap-rhel-byos/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap-rhel-byos/src/main/scripts/create-ds-mssqlserver.sh
@@ -53,7 +53,7 @@ sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \
 
 if [ "$(echo "$enablePswlessConnection" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
   # Create data source
-  dsConnectionString="$dsConnectionString;authentication=ActiveDirectoryMsi;msiClientId=${uamiClientId}"
+  dsConnectionString="$dsConnectionString;authentication=ActiveDirectoryMSI;msiClientId=${uamiClientId}"
 
   echo "data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter" | log
   sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \

--- a/eap-rhel-payg-multivm/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap-rhel-payg-multivm/src/main/scripts/create-ds-mssqlserver.sh
@@ -62,7 +62,7 @@ fi
 
 # Create data source
 if [ "$(echo "$enablePswlessConnection" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
-  dsConnectionString="$dsConnectionString;authentication=ActiveDirectoryMsi;msiClientId=${uamiClientId}"
+  dsConnectionString="$dsConnectionString;authentication=ActiveDirectoryMSI;msiClientId=${uamiClientId}"
   if [ $isManagedDomain == "false" ]; then
       echo "data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter" | log
       sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \

--- a/eap-rhel-payg/src/main/scripts/create-ds-mssqlserver.sh
+++ b/eap-rhel-payg/src/main/scripts/create-ds-mssqlserver.sh
@@ -53,7 +53,7 @@ sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \
 
 if [ "$(echo "$enablePswlessConnection" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
   # Create data source
-  dsConnectionString="$dsConnectionString;authentication=ActiveDirectoryMsi;msiClientId=${uamiClientId}"
+  dsConnectionString="$dsConnectionString;authentication=ActiveDirectoryMSI;msiClientId=${uamiClientId}"
 
   echo "data-source add --driver-name=sqlserver --name=${jdbcDataSourceName} --jndi-name=${jdbcDSJNDIName} --connection-url=${dsConnectionString} --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLExceptionSorter" | log
   sudo -u jboss $eapRootPath/bin/jboss-cli.sh --connect --echo-command \


### PR DESCRIPTION
## Changes
Both `ActiveDirectoryMsi ` and `ActiveDirectoryMSI` works, but it's better to use `ActiveDirectoryMSI` in the connection string for SQL Server, it is consistent with the naming convention and official documentation.